### PR TITLE
Add output_format: show to visualize config

### DIFF
--- a/config/visualize/general.yaml
+++ b/config/visualize/general.yaml
@@ -4,6 +4,7 @@ general:
   log10_min_value: 1.0e-4               # If negative values are being plotted on a log10 scale, values below this value are rounded up to it (e.g. to remove negative values).
   log10_max_value: 1.0e99               # If positive values are being plotted on a log10 scale, values above this value are rounded down to it (e.g. to prevent white blobs).
   zoom_around_mask: true                # If True, plots of data structures with a mask automatically zoom in the masked region.
+  output_format: show                   # Default output format: "show" displays the figure interactively via plt.show(), "png"/"pdf"/etc. saves to file.
 inversion:
   reconstruction_vmax_factor: 0.5   # Plots of an Inversion's reconstruction use the reconstructed data's bright value multiplied by this factor.
 zoom:


### PR DESCRIPTION
## Summary
- Add `output_format: show` to `config/visualize/general.yaml` so workspace scripts display plots interactively by default

## Test plan
- [x] Config loads correctly with existing plotting infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)