### PR TITLE
Add auto-simulate datasets to example scripts

### DIFF
--- a/scripts/ellipse/fit.py
+++ b/scripts/ellipse/fit.py
@@ -50,6 +50,21 @@ Ellipse fitting does not use the Point Spread Function (PSF) of the dataset, so 
 dataset_name = "ellipse"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/ellipse/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/ellipse/modeling.py
+++ b/scripts/ellipse/modeling.py
@@ -60,6 +60,21 @@ Ellipse fitting does not use the Point Spread Function (PSF) of the dataset, so 
 dataset_name = "ellipse"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/ellipse/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/ellipse/multipoles.py
+++ b/scripts/ellipse/multipoles.py
@@ -36,6 +36,21 @@ previous examples.
 dataset_name = "ellipse"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/ellipse/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/guides/advanced/over_sampling.py
+++ b/scripts/guides/advanced/over_sampling.py
@@ -333,6 +333,21 @@ profiles for which this over sampling scheme is applied.
 dataset_name = "simple__sersic"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/howtogalaxy/simulators/sersic.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/guides/data_structures.py
+++ b/scripts/guides/data_structures.py
@@ -217,6 +217,21 @@ We load an imaging dataset and illustrate its data structures below.
 dataset_name = "sersic_x2"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/guides/plot/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/guides/hpc/example_cpu_and_gpu.py
+++ b/scripts/guides/hpc/example_cpu_and_gpu.py
@@ -233,6 +233,21 @@ if not dataset_path.exists():
     dataset_folder = "imaging"
     dataset_path = Path(local_dataset_path, "dataset", dataset_folder, dataset_name)
 
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/guides/modeling/bug_fix.py
+++ b/scripts/guides/modeling/bug_fix.py
@@ -58,6 +58,21 @@ def fit():
     dataset_name = "simple"
     dataset_path = path.join("dataset", "imaging", dataset_name)
 
+    """
+    __Dataset Auto-Simulation__
+
+    If the dataset does not already exist on your system, it will be created by running the corresponding
+    simulator script. This ensures that all example scripts can be run without manually simulating data first.
+    """
+    if not Path(dataset_path).exists():
+        import subprocess
+        import sys
+        subprocess.run(
+            [sys.executable, "scripts/imaging/simulator.py"],
+            check=True,
+        )
+
+
     dataset = ag.Imaging.from_fits(
         data_path=path.join(dataset_path, "data.fits"),
         psf_path=path.join(dataset_path, "psf.fits"),

--- a/scripts/guides/modeling/chaining.py
+++ b/scripts/guides/modeling/chaining.py
@@ -47,6 +47,21 @@ Load, plot and mask the `Imaging` data.
 dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/guides/modeling/customize.py
+++ b/scripts/guides/modeling/customize.py
@@ -37,6 +37,21 @@ We therefore load and plot the strong dataset `simple` via .fits files.
 dataset_name = "simple__sersic"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/howtogalaxy/simulators/sersic.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/guides/plot/advanced/plotters_pixelization.py
+++ b/scripts/guides/plot/advanced/plotters_pixelization.py
@@ -39,6 +39,21 @@ grid = ag.Grid2D.uniform(shape_native=(100, 100), pixel_scales=0.05)
 dataset_name = "sersic_x2"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/guides/plot/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/guides/plot/examples/mat_plot.py
+++ b/scripts/guides/plot/examples/mat_plot.py
@@ -37,6 +37,21 @@ import autogalaxy as ag
 import autogalaxy.plot as aplt
 
 dataset_path = Path("dataset") / "imaging" / "complex"
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/guides/plot/simulator.py"],
+        check=True,
+    )
+
 data_path = dataset_path / "data.fits"
 data = ag.Array2D.from_fits(file_path=data_path, hdu=0, pixel_scales=0.1)
 

--- a/scripts/guides/plot/examples/plotters.py
+++ b/scripts/guides/plot/examples/plotters.py
@@ -48,6 +48,21 @@ grid = ag.Grid2D.uniform(shape_native=(100, 100), pixel_scales=0.05)
 dataset_name = "sersic_x2"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/guides/plot/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/guides/plot/examples/searches.py
+++ b/scripts/guides/plot/examples/searches.py
@@ -41,6 +41,21 @@ dataset_name = "simple__sersic"
 
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/howtogalaxy/simulators/sersic.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/guides/plot/examples/visuals.py
+++ b/scripts/guides/plot/examples/visuals.py
@@ -44,6 +44,21 @@ galaxy = ag.Galaxy(
 galaxies = ag.Galaxies(galaxies=[galaxy])
 
 dataset_path = Path("dataset") / "imaging" / "complex"
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/guides/plot/simulator.py"],
+        check=True,
+    )
+
 data_path = dataset_path / "data.fits"
 data = ag.Array2D.from_fits(file_path=data_path, hdu=0, pixel_scales=0.1)
 

--- a/scripts/guides/plot/start_here.py
+++ b/scripts/guides/plot/start_here.py
@@ -32,6 +32,21 @@ __Dataset__
 First, lets load an example image of a galaxy as an `Array2D`.
 """
 dataset_path = Path("dataset") / "imaging" / "complex"
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/guides/plot/simulator.py"],
+        check=True,
+    )
+
 data_path = dataset_path / "data.fits"
 data = ag.Array2D.from_fits(file_path=data_path, hdu=0, pixel_scales=0.1)
 

--- a/scripts/guides/results/examples/galaxies_fit.py
+++ b/scripts/guides/results/examples/galaxies_fit.py
@@ -61,6 +61,21 @@ You should be familiar with modeling already, if not read the `modeling/start_he
 dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/guides/results/examples/samples.py
+++ b/scripts/guides/results/examples/samples.py
@@ -44,6 +44,21 @@ You should be familiar with modeling already, if not read the `modeling/start_he
 dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/guides/results/start_here.py
+++ b/scripts/guides/results/start_here.py
@@ -39,6 +39,21 @@ You should be familiar with modeling already, if not read the `modeling/start_he
 dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/guides/results/workflow/csv_make.py
+++ b/scripts/guides/results/workflow/csv_make.py
@@ -73,6 +73,21 @@ for i in range(2):
     dataset_name = f"simple"
     dataset_path = Path("dataset") / "imaging" / dataset_name
 
+    """
+    __Dataset Auto-Simulation__
+
+    If the dataset does not already exist on your system, it will be created by running the corresponding
+    simulator script. This ensures that all example scripts can be run without manually simulating data first.
+    """
+    if not dataset_path.exists():
+        import subprocess
+        import sys
+        subprocess.run(
+            [sys.executable, "scripts/imaging/simulator.py"],
+            check=True,
+        )
+
+
     dataset = ag.Imaging.from_fits(
         data_path=dataset_path / "data.fits",
         psf_path=dataset_path / "psf.fits",

--- a/scripts/guides/results/workflow/fits_make.py
+++ b/scripts/guides/results/workflow/fits_make.py
@@ -86,6 +86,21 @@ for i in range(2):
     dataset_name = f"simple"
     dataset_path = Path("dataset") / "imaging" / dataset_name
 
+    """
+    __Dataset Auto-Simulation__
+
+    If the dataset does not already exist on your system, it will be created by running the corresponding
+    simulator script. This ensures that all example scripts can be run without manually simulating data first.
+    """
+    if not dataset_path.exists():
+        import subprocess
+        import sys
+        subprocess.run(
+            [sys.executable, "scripts/imaging/simulator.py"],
+            check=True,
+        )
+
+
     dataset = ag.Imaging.from_fits(
         data_path=dataset_path / "data.fits",
         psf_path=dataset_path / "psf.fits",

--- a/scripts/guides/results/workflow/png_make.py
+++ b/scripts/guides/results/workflow/png_make.py
@@ -89,6 +89,21 @@ for i in range(2):
     dataset_name = f"simple"
     dataset_path = Path("dataset") / "imaging" / dataset_name
 
+    """
+    __Dataset Auto-Simulation__
+
+    If the dataset does not already exist on your system, it will be created by running the corresponding
+    simulator script. This ensures that all example scripts can be run without manually simulating data first.
+    """
+    if not dataset_path.exists():
+        import subprocess
+        import sys
+        subprocess.run(
+            [sys.executable, "scripts/imaging/simulator.py"],
+            check=True,
+        )
+
+
     dataset = ag.Imaging.from_fits(
         data_path=dataset_path / "data.fits",
         psf_path=dataset_path / "psf.fits",

--- a/scripts/howtogalaxy/chapter_1_introduction/tutorial_0_visualization.py
+++ b/scripts/howtogalaxy/chapter_1_introduction/tutorial_0_visualization.py
@@ -51,6 +51,21 @@ There are many example simulated images of galaxies in this directory that will 
 dataset_path = Path("dataset", "imaging", "simple__sersic")
 
 """
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/howtogalaxy/simulators/sersic.py"],
+        check=True,
+    )
+
+
+"""
 We now load this dataset from .fits files and create an instance of an `imaging` object.
 """
 dataset = ag.Imaging.from_fits(

--- a/scripts/howtogalaxy/chapter_1_introduction/tutorial_3_fitting.py
+++ b/scripts/howtogalaxy/chapter_1_introduction/tutorial_3_fitting.py
@@ -51,6 +51,21 @@ The `dataset_path` below specifies where these files are located: `autogalaxy_wo
 """
 dataset_path = Path("dataset", "imaging", "howtogalaxy")
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/howtogalaxy/chapter_2_modeling/tutorial_1_non_linear_search.py
+++ b/scripts/howtogalaxy/chapter_2_modeling/tutorial_1_non_linear_search.py
@@ -202,6 +202,21 @@ the `autogalaxy_workspace/dataset/imaging` folder.
 dataset_name = "simple__sersic"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/howtogalaxy/simulators/sersic.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/howtogalaxy/chapter_2_modeling/tutorial_2_practicalities.py
+++ b/scripts/howtogalaxy/chapter_2_modeling/tutorial_2_practicalities.py
@@ -70,6 +70,21 @@ to illustrate the practicalities of model-fitting in this tutorial.
 dataset_name = "simple__sersic"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/howtogalaxy/simulators/sersic.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/howtogalaxy/chapter_2_modeling/tutorial_3_realism_and_complexity.py
+++ b/scripts/howtogalaxy/chapter_2_modeling/tutorial_3_realism_and_complexity.py
@@ -40,6 +40,21 @@ we'll use new galaxying data, where:
 dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/howtogalaxy/chapter_2_modeling/tutorial_4_dealing_with_failure.py
+++ b/scripts/howtogalaxy/chapter_2_modeling/tutorial_4_dealing_with_failure.py
@@ -42,6 +42,21 @@ we'll use the same galaxy data as the previous tutorial, where:
 dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/howtogalaxy/chapter_2_modeling/tutorial_5_linear_profiles.py
+++ b/scripts/howtogalaxy/chapter_2_modeling/tutorial_5_linear_profiles.py
@@ -47,6 +47,21 @@ we'll use the same galaxy data as the previous tutorial, where:
 dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/howtogalaxy/chapter_2_modeling/tutorial_6_masking.py
+++ b/scripts/howtogalaxy/chapter_2_modeling/tutorial_6_masking.py
@@ -28,6 +28,21 @@ we'll use the same galaxy data as tutorials 1 & 2, where:
 dataset_name = "simple__sersic"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/howtogalaxy/simulators/sersic.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/howtogalaxy/chapter_2_modeling/tutorial_7_results.py
+++ b/scripts/howtogalaxy/chapter_2_modeling/tutorial_7_results.py
@@ -25,6 +25,21 @@ Lets use the model-fit performed in tutorial 1 to get a `Result` object.
 dataset_name = "simple__sersic"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/howtogalaxy/simulators/sersic.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/howtogalaxy/chapter_3_search_chaining/tutorial_1_search_chaining.py
+++ b/scripts/howtogalaxy/chapter_3_search_chaining/tutorial_1_search_chaining.py
@@ -59,6 +59,21 @@ we'll use the same galaxy data as tutorial 4 of chapter 2, where:
 dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/howtogalaxy/chapter_3_search_chaining/tutorial_2_prior_passing.py
+++ b/scripts/howtogalaxy/chapter_3_search_chaining/tutorial_2_prior_passing.py
@@ -36,6 +36,21 @@ All the usual steps for setting up a model fit (masking, analysis, etc.) are inc
 dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/howtogalaxy/chapter_3_search_chaining/tutorial_3_x2_galaxies.py
+++ b/scripts/howtogalaxy/chapter_3_search_chaining/tutorial_3_x2_galaxies.py
@@ -37,6 +37,21 @@ we'll use new galaxying data, where:
 dataset_name = "sersic_x2"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/guides/plot/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/howtogalaxy/chapter_4_pixelizations/tutorial_2_mappers.py
+++ b/scripts/howtogalaxy/chapter_4_pixelizations/tutorial_2_mappers.py
@@ -28,8 +28,22 @@ we'll use complex galaxy data, where:
  - The galaxy's disk is an `Exponential`.
  - The galaxy's has four star forming clumps which are `Sersic` profiles.
 """
-dataset_name = "complex"
+dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
 
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",

--- a/scripts/howtogalaxy/chapter_4_pixelizations/tutorial_3_inversions.py
+++ b/scripts/howtogalaxy/chapter_4_pixelizations/tutorial_3_inversions.py
@@ -31,8 +31,22 @@ we'll use the same complex galaxy data as the previous tutorial, where:
  - The galaxy's disk is an `Exponential`.
  - The galaxy's has four star forming clumps which are `Sersic` profiles.
 """
-dataset_name = "complex"
+dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
 
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",

--- a/scripts/howtogalaxy/chapter_4_pixelizations/tutorial_4_bayesian_regularization.py
+++ b/scripts/howtogalaxy/chapter_4_pixelizations/tutorial_4_bayesian_regularization.py
@@ -33,8 +33,22 @@ we'll use the same complex galaxy data as the previous tutorial, where:
  - The galaxy's disk is an `Exponential`.
  - The galaxy's has four star forming clumps which are `Sersic` profiles.
 """
-dataset_name = "complex"
+dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
 
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",

--- a/scripts/howtogalaxy/chapter_4_pixelizations/tutorial_5_model_fit.py
+++ b/scripts/howtogalaxy/chapter_4_pixelizations/tutorial_5_model_fit.py
@@ -40,8 +40,22 @@ we'll use complex galaxy data, where:
  - The galaxy's disk is an `Exponential`.
  - The galaxy's has four star forming clumps which are `Sersic` profiles.
 """
-dataset_name = "complex"
+dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
+
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
 
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",

--- a/scripts/howtogalaxy/chapter_optional/tutorial_searches.py
+++ b/scripts/howtogalaxy/chapter_optional/tutorial_searches.py
@@ -33,6 +33,21 @@ we'll use new galaxying data, where:
 dataset_name = "simple__sersic"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/howtogalaxy/simulators/sersic.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/imaging/features/extra_galaxies/modeling.py
+++ b/scripts/imaging/features/extra_galaxies/modeling.py
@@ -58,6 +58,21 @@ Load and plot the dataset `extra_galaxies` via .fits files.
 dataset_name = "extra_galaxies"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/features/extra_galaxies/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/features/linear_light_profiles/fit.py
+++ b/scripts/imaging/features/linear_light_profiles/fit.py
@@ -82,6 +82,21 @@ Load and plot the galaxy dataset `simple` via .fits files.
 dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/features/linear_light_profiles/likelihood_function.py
+++ b/scripts/imaging/features/linear_light_profiles/likelihood_function.py
@@ -49,6 +49,21 @@ set oversampling to 1.
 """
 dataset_path = Path("dataset", "imaging", "simple")
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/features/linear_light_profiles/modeling.py
+++ b/scripts/imaging/features/linear_light_profiles/modeling.py
@@ -87,6 +87,21 @@ Load and plot the galaxy dataset `simple` via .fits files.
 dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/features/multi_gaussian_expansion/fit.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/fit.py
@@ -94,6 +94,21 @@ Load and plot the galaxy dataset `light_basis` via .fits files.
 dataset_name = "asymmetric"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/features/multi_gaussian_expansion/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/features/multi_gaussian_expansion/likelihood_function.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/likelihood_function.py
@@ -55,6 +55,21 @@ fitted with `Sersic` profile and therefore requires a multi-Gaussian expansion t
 dataset_name = "asymmetric"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/features/multi_gaussian_expansion/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/features/multi_gaussian_expansion/modeling.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/modeling.py
@@ -96,6 +96,21 @@ Load and plot the galaxy dataset `asymetric` via .fits files.
 dataset_name = "asymmetric"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/features/multi_gaussian_expansion/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/features/operated_light_profile/modeling.py
+++ b/scripts/imaging/features/operated_light_profile/modeling.py
@@ -63,6 +63,21 @@ Load and plot the galaxy dataset `operated` via .fits files.
 dataset_name = "operated"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/features/operated_light_profile/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/features/pixelization/fit.py
+++ b/scripts/imaging/features/pixelization/fit.py
@@ -109,6 +109,21 @@ Load and plot the strong lens dataset `simple__sersic` via .fits files.
 dataset_name = "simple__sersic"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/howtogalaxy/simulators/sersic.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/features/pixelization/likelihood_function.py
+++ b/scripts/imaging/features/pixelization/likelihood_function.py
@@ -57,6 +57,21 @@ resolution than the best quality Hubble Space Telescope imaging and close to tha
 """
 dataset_path = Path("dataset", "imaging", "simple")
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/features/pixelization/modeling.py
+++ b/scripts/imaging/features/pixelization/modeling.py
@@ -150,6 +150,21 @@ Load and plot the strong lens dataset `simple__sersic` via .fits files
 dataset_name = "simple__sersic"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/howtogalaxy/simulators/sersic.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/features/pixelization/source_science.py
+++ b/scripts/imaging/features/pixelization/source_science.py
@@ -35,6 +35,21 @@ outputs the pixelization source reconstruction to a .csv file.
 dataset_name = "simple__sersic"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/howtogalaxy/simulators/sersic.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/features/shapelets/fit.py
+++ b/scripts/imaging/features/shapelets/fit.py
@@ -90,6 +90,21 @@ the model.
 dataset_name = "simple__sersic"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/howtogalaxy/simulators/sersic.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/features/shapelets/modeling.py
+++ b/scripts/imaging/features/shapelets/modeling.py
@@ -92,6 +92,21 @@ the model.
 dataset_name = "simple__sersic"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/howtogalaxy/simulators/sersic.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/features/sky_background/fit.py
+++ b/scripts/imaging/features/sky_background/fit.py
@@ -57,6 +57,21 @@ the image.
 dataset_name = "sky_background"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/features/sky_background/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/features/sky_background/modeling.py
+++ b/scripts/imaging/features/sky_background/modeling.py
@@ -57,6 +57,21 @@ the image.
 dataset_name = "sky_background"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/features/sky_background/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/fit.py
+++ b/scripts/imaging/fit.py
@@ -54,6 +54,21 @@ demonstrate fitting.
 dataset_name = "sersic_x2"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/guides/plot/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/likelihood_function.py
+++ b/scripts/imaging/likelihood_function.py
@@ -37,6 +37,21 @@ This example fits a simulated galaxy where the imaging resolution is 0.1 arcseco
 """
 dataset_path = Path("dataset", "imaging", "simple")
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/modeling.py
+++ b/scripts/imaging/modeling.py
@@ -57,6 +57,21 @@ is 0.1" / pixel.
 dataset_name = "simple"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/imaging/start_here.py
+++ b/scripts/imaging/start_here.py
@@ -92,6 +92,21 @@ correctly for your data.
 dataset_name = "extra_galaxies"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/imaging/features/extra_galaxies/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/interferometer/features/pixelization/fit.py
+++ b/scripts/interferometer/features/pixelization/fit.py
@@ -141,6 +141,21 @@ the data from the repository described in the "High Resolution Dataset" section 
 dataset_name = "simple"
 dataset_path = Path("dataset") / "interferometer" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Interferometer.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/interferometer/features/pixelization/likelihood_function.py
+++ b/scripts/interferometer/features/pixelization/likelihood_function.py
@@ -71,6 +71,21 @@ function changes for different methods of Fourier transforming in this guide.
 dataset_name = "simple"
 dataset_path = Path("dataset") / "interferometer" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Interferometer.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/interferometer/features/pixelization/modeling.py
+++ b/scripts/interferometer/features/pixelization/modeling.py
@@ -165,6 +165,21 @@ the data from the repository described in the "High Resolution Dataset" section 
 dataset_name = "simple"
 dataset_path = Path("dataset") / "interferometer" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Interferometer.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/interferometer/features/pixelization/source_science.py
+++ b/scripts/interferometer/features/pixelization/source_science.py
@@ -43,6 +43,21 @@ real_space_mask = ag.Mask2D.circular(
 dataset_name = "simple"
 dataset_path = Path("dataset") / "interferometer" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Interferometer.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/interferometer/fit.py
+++ b/scripts/interferometer/fit.py
@@ -57,6 +57,21 @@ the real-space image to the uv-plane.
 dataset_name = "simple"
 dataset_path = Path("dataset") / "interferometer" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Interferometer.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/interferometer/likelihood_function.py
+++ b/scripts/interferometer/likelihood_function.py
@@ -51,6 +51,21 @@ function changes for different methods of Fourier transforming in this guide.
 dataset_name = "simple"
 dataset_path = Path("dataset") / "interferometer" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Interferometer.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/interferometer/modeling.py
+++ b/scripts/interferometer/modeling.py
@@ -69,6 +69,21 @@ interferometer datasets containing ~1-10 million visibilities.
 dataset_name = "simple"
 dataset_path = Path("dataset") / "interferometer" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Interferometer.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/interferometer/start_here.py
+++ b/scripts/interferometer/start_here.py
@@ -131,6 +131,21 @@ the computation being too slow (for larger datasets with many visibilities the N
 dataset_name = "simple"
 dataset_path = Path("dataset") / "interferometer" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/interferometer/simulator.py"],
+        check=True,
+    )
+
+
 dataset = ag.Interferometer.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/multi/features/dataset_offsets/modeling.py
+++ b/scripts/multi/features/dataset_offsets/modeling.py
@@ -90,6 +90,21 @@ dataset_name = "dataset_offsets"
 
 dataset_path = Path("dataset") / dataset_type / dataset_label / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/multi/features/dataset_offsets/simulator.py"],
+        check=True,
+    )
+
+
 dataset_list = [
     ag.Imaging.from_fits(
         data_path=Path(dataset_path) / f"{waveband}_data.fits",

--- a/scripts/multi/features/imaging_and_interferometer/modeling.py
+++ b/scripts/multi/features/imaging_and_interferometer/modeling.py
@@ -46,6 +46,21 @@ dataset_label = "interferometer"
 dataset_name = "simple"
 dataset_path = Path("dataset") / dataset_type / dataset_label / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/multi/simulator.py"],
+        check=True,
+    )
+
+
 interferometer = ag.Interferometer.from_fits(
     data_path=dataset_path / "data.fits",
     noise_map_path=dataset_path / "noise_map.fits",

--- a/scripts/multi/features/one_by_one/modeling.py
+++ b/scripts/multi/features/one_by_one/modeling.py
@@ -84,6 +84,21 @@ dataset_name = "simple"
 
 dataset_path = Path("dataset") / dataset_type / dataset_label / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/multi/simulator.py"],
+        check=True,
+    )
+
+
 dataset_list = [
     ag.Imaging.from_fits(
         data_path=Path(dataset_path) / f"{waveband}_data.fits",

--- a/scripts/multi/features/pixelization/modeling.py
+++ b/scripts/multi/features/pixelization/modeling.py
@@ -54,6 +54,21 @@ dataset_name = "simple"
 
 dataset_path = Path("dataset") / dataset_type / dataset_label / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/multi/simulator.py"],
+        check=True,
+    )
+
+
 dataset_list = [
     ag.Imaging.from_fits(
         data_path=Path(dataset_path) / f"{waveband}_data.fits",

--- a/scripts/multi/features/same_wavelength/modeling.py
+++ b/scripts/multi/features/same_wavelength/modeling.py
@@ -51,6 +51,21 @@ dataset_name = "same_wavelength"
 
 dataset_path = Path("dataset") / dataset_type / dataset_label / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/multi/features/same_wavelength/simulator.py"],
+        check=True,
+    )
+
+
 dataset_list = [
     ag.Imaging.from_fits(
         data_path=Path(dataset_path, f"image_{i}.fits"),

--- a/scripts/multi/features/wavelength_dependence/modeling.py
+++ b/scripts/multi/features/wavelength_dependence/modeling.py
@@ -72,6 +72,21 @@ dataset_name = "wavelength_dependence"
 
 dataset_path = Path("dataset") / dataset_type / dataset_label / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/multi/features/wavelength_dependence/simulator.py"],
+        check=True,
+    )
+
+
 dataset_list = [
     ag.Imaging.from_fits(
         data_path=Path(dataset_path) / f"{waveband}_data.fits",

--- a/scripts/multi/modeling.py
+++ b/scripts/multi/modeling.py
@@ -53,6 +53,21 @@ dataset_name = "simple"
 
 dataset_path = Path("dataset") / dataset_type / dataset_label / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/multi/simulator.py"],
+        check=True,
+    )
+
+
 dataset_list = [
     ag.Imaging.from_fits(
         data_path=Path(dataset_path) / f"{waveband}_data.fits",

--- a/scripts/multi/plot.py
+++ b/scripts/multi/plot.py
@@ -32,6 +32,21 @@ First, load example imaging of a galaxy and create a `FitImaging` object.
 dataset_name = "simple__sersic"
 dataset_path = Path("dataset") / "imaging" / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/howtogalaxy/simulators/sersic.py"],
+        check=True,
+    )
+
+
 dataset = ag.Imaging.from_fits(
     data_path=dataset_path / "data.fits",
     psf_path=dataset_path / "psf.fits",

--- a/scripts/multi/start_here.py
+++ b/scripts/multi/start_here.py
@@ -109,6 +109,21 @@ dataset_name = "simple"
 
 dataset_path = Path("dataset") / dataset_type / dataset_label / dataset_name
 
+"""
+__Dataset Auto-Simulation__
+
+If the dataset does not already exist on your system, it will be created by running the corresponding
+simulator script. This ensures that all example scripts can be run without manually simulating data first.
+"""
+if not dataset_path.exists():
+    import subprocess
+    import sys
+    subprocess.run(
+        [sys.executable, "scripts/multi/simulator.py"],
+        check=True,
+    )
+
+
 dataset_list = []
 
 for dataset_waveband in waveband_list:

--- a/smoke_tests.txt
+++ b/smoke_tests.txt
@@ -1,0 +1,8 @@
+imaging/start_here.py
+imaging/fit.py
+imaging/modeling.py
+interferometer/start_here.py
+multi/start_here.py
+ellipse/modeling.py
+guides/galaxies.py
+guides/modeling/cookbook.py


### PR DESCRIPTION
## Summary
- Add auto-simulate snippet to 75 example scripts so they automatically run the corresponding simulator when the dataset doesn't exist
- Swap complex → simple dataset in howtogalaxy chapter_4 pixelization tutorials (4 files)

## Test plan
- [x] Ran `scripts/imaging/modeling.py` with PYAUTOFIT_TEST_MODE=1 — passed
- [x] Ran `scripts/ellipse/modeling.py` with PYAUTOFIT_TEST_MODE=1 — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)