### PR TITLE
fix: remove dead fit_plotter.figures_2d block in interferometer/fit.py

### DIFF
--- a/notebooks/interferometer/fit.ipynb
+++ b/notebooks/interferometer/fit.ipynb
@@ -285,30 +285,6 @@
         " - The `normalized_residual_map`: The `residual_map `divided by the observed dataset's `noise_map`.\n",
         " - The `chi_squared_map`: The `normalized_residual_map` squared.\n",
         "\n",
-        "For a good galaxy model where the model and galaxies are representative of the dataset\n",
-        "residuals, normalized residuals and chi-squareds are minimized:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "aplt.plot_array(array=fit.residual_map.real, title=\"Residual Map (Real)\")\n",
-        "fit_plotter.figures_2d(\n",
-        "    residual_map_imag=True,\n",
-        "    normalized_residual_map_real=True,\n",
-        "    normalized_residual_map_imag=True,\n",
-        "    chi_squared_map_real=True,\n",
-        "    chi_squared_map_imag=True,\n",
-        ")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
         "A subplot can be plotted which contains all of the above quantities, as well as other information contained in the\n",
         "galaxies such as the image and a normalized residual map where the colorbar\n",
         "goes from 1.0 sigma to -1.0 sigma, to highlight regions where the fit is poor."

--- a/scripts/interferometer/fit.py
+++ b/scripts/interferometer/fit.py
@@ -173,19 +173,6 @@ The fit does a lot more than just Fourier transform the galaxy image it also cre
  - The `normalized_residual_map`: The `residual_map `divided by the observed dataset's `noise_map`.
  - The `chi_squared_map`: The `normalized_residual_map` squared.
 
-For a good galaxy model where the model and galaxies are representative of the dataset
-residuals, normalized residuals and chi-squareds are minimized:
-"""
-aplt.plot_array(array=fit.residual_map.real, title="Residual Map (Real)")
-fit_plotter.figures_2d(
-    residual_map_imag=True,
-    normalized_residual_map_real=True,
-    normalized_residual_map_imag=True,
-    chi_squared_map_real=True,
-    chi_squared_map_imag=True,
-)
-
-"""
 A subplot can be plotted which contains all of the above quantities, as well as other information contained in the
 galaxies such as the image and a normalized residual map where the colorbar
 goes from 1.0 sigma to -1.0 sigma, to highlight regions where the fit is poor.


### PR DESCRIPTION
## Summary
- Category F fix: lines 179-186 referenced `fit_plotter` which was never instantiated and called `figures_2d(...)` — a method that doesn't exist on the interferometer plot API.
- The block was latent dead code, hidden behind the earlier `subplot_interferometer_dataset` failure on line 101 (fixed in PyAutoGalaxy#337).
- The subsequent `aplt.subplot_fit_interferometer(fit=fit)` call already visualizes residual / normalized residual / chi-squared maps, so no functionality is lost.

## Test plan
- [x] `python scripts/interferometer/fit.py` now runs past line 101 and 179 cleanly. (Further failure at line 303 is Category C — `output_to_fits` removed, to be fixed separately.)
- Depends on: PyAutoLabs/PyAutoGalaxy#337

🤖 Generated with [Claude Code](https://claude.com/claude-code)