### PR TITLE
fix: use aplt.fits_array for Array2D output in interferometer/fit.py

### DIFF
--- a/notebooks/interferometer/fit.ipynb
+++ b/notebooks/interferometer/fit.ipynb
@@ -527,8 +527,10 @@
       "metadata": {},
       "source": [
         "galaxy_model_image = fit.galaxy_image_dict[galaxy]\n",
-        "galaxy_model_image.output_to_fits(\n",
-        "    file_path=dataset_path / \"galaxy_model_image.fits\", overwrite=True\n",
+        "aplt.fits_array(\n",
+        "    array=galaxy_model_image,\n",
+        "    file_path=dataset_path / \"galaxy_model_image.fits\",\n",
+        "    overwrite=True,\n",
         ")"
       ],
       "outputs": [],

--- a/scripts/interferometer/fit.py
+++ b/scripts/interferometer/fit.py
@@ -300,8 +300,10 @@ For example, one could output the galaxy model image to a .fits file such that
 we could fit this image again with an independent pipeline.
 """
 galaxy_model_image = fit.galaxy_image_dict[galaxy]
-galaxy_model_image.output_to_fits(
-    file_path=dataset_path / "galaxy_model_image.fits", overwrite=True
+aplt.fits_array(
+    array=galaxy_model_image,
+    file_path=dataset_path / "galaxy_model_image.fits",
+    overwrite=True,
 )
 
 """


### PR DESCRIPTION
## Summary
Category C fix — `Array2D.output_to_fits(...)` was removed. Replace the call at line 303 with `aplt.fits_array(array=..., file_path=..., overwrite=True)`, the current API for writing an Array2D to a FITS file.

## Test plan
- [x] `python scripts/interferometer/fit.py` runs end-to-end (EXIT=0). This was the last outstanding failure in this script after the Category F fix in #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)