### PR TITLE
SLOW-skip 2 aggregator-cascade guides/results scripts

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -14,7 +14,9 @@
 - guides/results/start_here # SLOW 2026-04-10 - exceeds 60s test timeout; unsets TEST_MODE to produce real samples for downstream examples
 - guides/results/examples/galaxies_fit # SLOW 2026-04-10 - exceeds 60s test timeout; unsets TEST_MODE for downstream examples
 - guides/results/examples/samples # SLOW 2026-04-10 - exceeds 60s test timeout; unsets TEST_MODE for downstream examples
+- guides/results/examples/models # SLOW 2026-04-10 - cascade from SLOW-skipped results/start_here.py; aggregator returns NoneType so instance.galaxies is None
 - guides/results/workflow/csv_make # SLOW 2026-04-10 - exceeds 60s test timeout; unsets TEST_MODE for downstream examples
+- guides/results/database/start_here # SLOW 2026-04-10 - previously failed fast on a broken aggregator query; now runs the real aggregator and exceeds 60s
 - gui/light_centre # GUI scripts cannot be run
 - gui/mask_extra_galaxies # GUI scripts cannot be run
 - gui/mask # GUI scripts cannot be run


### PR DESCRIPTION
## Summary
- `guides/results/database/start_here` previously failed fast on a broken aggregator query, but after recent fixes now runs the real aggregator and exceeds the 60s per-script test timeout.
- `guides/results/examples/models` cascades from the already-SLOW-skipped `guides/results/start_here.py`: the stub aggregator returns `None`, so `instance.galaxies` is `None` and the script crashes.
- Both are tagged with the standard `# SLOW 2026-04-10 - <reason>` marker so the mega-run surfaces them every run until fixed.

## Test plan
- [x] Entries appended under the existing SLOW block in `config/build/no_run.yaml`
- [ ] Next mega-run confirms the 2 scripts are counted as skipped rather than failed

Generated with [Claude Code](https://claude.com/claude-code)