### PR TITLE
Park 8 NEEDS_FIX scripts (API drift + PD regressions)

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -9,6 +9,13 @@
 #   skipped because they exceed the 60s per-script timeout cap. These are
 #   NOT permanent skips — every mega-run surfaces them with a loud warning
 #   banner. Fix the performance issue and remove the SLOW marker.
+#
+# NEEDS_FIX convention:
+#   Entries tagged `# NEEDS_FIX <YYYY-MM-DD> - <reason>` mark scripts that
+#   are broken and parked as a to-do list. Like SLOW-skips, these are NOT
+#   permanent skips — every mega-run surfaces them with a loud warning
+#   banner. Investigate the failure, fix the underlying bug, and remove
+#   the NEEDS_FIX marker.
 
 - tutorial_searches
 - guides/results/start_here # SLOW 2026-04-10 - exceeds 60s test timeout; unsets TEST_MODE to produce real samples for downstream examples
@@ -26,3 +33,11 @@
 - examples/searches # Test mode breaks search visualization.
 - data_fitting # Test mode breaks .fits file output
 - ellipse/database # Ellipse model needs refactor and JAX support
+- ellipse/modeling # NEEDS_FIX 2026-04-10 - KeyError on 'ellipses.0.centre_0' kwargs after API drift in ellipse model
+- guides/advanced/over_sampling # NEEDS_FIX 2026-04-10 - plot_grid() got unexpected kwarg 'plot_grid_lines' after plotter API drift
+- howtogalaxy/chapter_4_pixelizations/tutorial_2_mappers # NEEDS_FIX 2026-04-10 - IndexError in mapper tutorial, likely empty mapping array
+- howtogalaxy/chapter_4_pixelizations/tutorial_5_model_fit # NEEDS_FIX 2026-04-10 - LinAlgError: matrix not positive definite in pixelization fit
+- imaging/data_preparation/manual/mask_irregular # NEEDS_FIX 2026-04-10 - silent failure, needs investigation
+- imaging/features/pixelization/modeling # NEEDS_FIX 2026-04-10 - LinAlgError: matrix not positive definite in pixelization modeling
+- autogalaxy_workspace/scripts/imaging/modeling # NEEDS_FIX 2026-04-10 - KeyError on ('galaxies','galaxy','bulge','ell_comps'...) kwargs after API drift in top-level imaging/modeling.py
+- interferometer/features/pixelization/modeling # NEEDS_FIX 2026-04-10 - LinAlgError: matrix not positive definite in interferometer pixelization modeling


### PR DESCRIPTION
## Summary
Adds the NEEDS_FIX header block and parks 8 scripts that are failing under the current mega-run env. These are surfaced on every run by the updated slow_skip_check scanner (PyAutoLabs/PyAutoBuild#41).

## API Changes
None — config-only change.

## Test Plan
- [x] `python PyAutoBuild/autobuild/slow_skip_check.py` — 8 NEEDS_FIX entries picked up
- [x] Pattern precision verified: `autogalaxy_workspace/scripts/imaging/modeling` only matches the top-level `imaging/modeling.py`, not the 8 other `modeling.py` siblings

Parked scripts:
- `ellipse/modeling` — `KeyError` on `ellipses.0.centre_0` kwargs
- `guides/advanced/over_sampling` — `plot_grid()` unexpected kwarg `plot_grid_lines`
- `howtogalaxy/chapter_4_pixelizations/tutorial_2_mappers` — `IndexError`
- `howtogalaxy/chapter_4_pixelizations/tutorial_5_model_fit` — `LinAlgError` not PD
- `imaging/data_preparation/manual/mask_irregular` — silent failure
- `imaging/features/pixelization/modeling` — `LinAlgError` not PD
- top-level `imaging/modeling.py` — `KeyError` on galaxies/bulge kwargs
- `interferometer/features/pixelization/modeling` — `LinAlgError` not PD

🤖 Generated with [Claude Code](https://claude.com/claude-code)