### PR TITLE
fix: unset PYAUTO_SMALL_DATASETS for howtogalaxy and guides

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -21,8 +21,11 @@ defaults:
   MPLCONFIGDIR: "/tmp/matplotlib"       # Writable config dir for matplotlib
 
 overrides:
-  # Tutorial loads FITS data at full resolution
-  - pattern: "howtogalaxy/chapter_1_introduction/tutorial_3_fitting"
+  # Non-simulator scripts that load committed FITS data need full-size
+  # datasets to avoid shape mismatch with pre-existing 100x100 data.
+  - pattern: "howtogalaxy/"
+    unset: [PYAUTO_SMALL_DATASETS]
+  - pattern: "guides/"
     unset: [PYAUTO_SMALL_DATASETS]
   # guides/results/start_here.py must produce real samples so the example
   # scripts that read from `output/results_folder` afterwards


### PR DESCRIPTION
## Summary

Unset `PYAUTO_SMALL_DATASETS` for `howtogalaxy/` and `guides/` script paths in `config/build/env_vars.yaml`. These scripts load committed FITS data at full resolution (100x100) but the env var caps masks to 15x15, causing shape mismatch errors in the release build.

Relates to Jammy2211/PyAutoArray#269.

## API Changes
None — build configuration only.

## Test Plan
- [ ] Re-trigger release build after merging all PRs in this task

🤖 Generated with [Claude Code](https://claude.com/claude-code)