### PR TITLE
refactor: replace Grid1D with Grid2DIrregular for radial profiles

### DIFF
--- a/scripts/guides/galaxies.py
+++ b/scripts/guides/galaxies.py
@@ -46,6 +46,7 @@ These are documented fully in the `autogalaxy_workspace/*/guides/data_structures
 # from autoconf import setup_notebook; setup_notebook()
 
 import matplotlib.pyplot as plt
+import numpy as np
 from pathlib import Path
 import autofit as af
 import autogalaxy as ag
@@ -387,13 +388,14 @@ plt.show()
 plt.close()
 
 """
-If we want a specific 1D grid of a certain length over a certain range of coordinates, we can manually input a `Grid1D`
-object.
+If we want a specific 1D radial profile over a certain range of coordinates, we create a `Grid2DIrregular` of
+(y,x) coordinates along the x-axis and evaluate the image on it.
 """
-grid_1d = ag.Grid1D.uniform_from_zero(shape_native=(10000,), pixel_scales=0.01)
-image_1d = galaxy_0.image_2d_from(grid=grid_1d)
+radii = np.arange(10000) * 0.01
+grid_radial = ag.Grid2DIrregular(values=[(0.0, r) for r in radii])
+image_1d = galaxy_0.image_2d_from(grid=grid_radial)
 
-plt.plot(grid_1d, image_1d)
+plt.plot(radii, image_1d)
 plt.xlabel("Radius (arcseconds)")
 plt.ylabel("Luminosity")
 plt.show()

--- a/scripts/guides/plot/examples/plotters.py
+++ b/scripts/guides/plot/examples/plotters.py
@@ -37,6 +37,7 @@ To illustrate plotting, we require standard objects like a grid, dataset and fit
 
 import matplotlib.pyplot as plt
 import math
+import numpy as np
 
 from pathlib import Path
 import autogalaxy as ag
@@ -217,13 +218,13 @@ plt.show()
 plt.close()
 
 """
-Using a `Grid1D` which does not start from 0.0" plots the 1D quantity with both negative and positive radial
-coordinates.
+Using a radial grid of (y,x) coordinates along the x-axis plots the 1D radial profile.
 """
-grid_1d = ag.Grid1D.uniform_from_zero(shape_native=(10000,), pixel_scales=0.01)
-image_1d = galaxy_0.image_2d_from(grid=grid_1d)
+radii = np.arange(10000) * 0.01
+grid_radial = ag.Grid2DIrregular(values=[(0.0, r) for r in radii])
+image_1d = galaxy_0.image_2d_from(grid=grid_radial)
 
-plt.plot(grid_1d, image_1d)
+plt.plot(radii, image_1d)
 plt.xlabel("Radius (arcseconds)")
 plt.ylabel("Luminosity")
 plt.show()


### PR DESCRIPTION
## Summary
- Replace `Grid1D.uniform_from_zero()` with `Grid2DIrregular` for 1D radial profile plots
- Part of PyAutoArray decorator cleanup (PyAutoArray#277) which removes Grid1D from the type-dispatch system

## API Changes
None — internal script change only. `Grid2DIrregular` is used instead of `Grid1D` for radial profile evaluation.

## Test Plan
- [x] `scripts/guides/galaxies.py` passes smoke test
- [x] `scripts/guides/plot/examples/plotters.py` — not in smoke tests but follows same pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)