### PR TITLE
chore: replay orphaned release PR #28 onto main

### DIFF
--- a/scripts/guides/galaxies.py
+++ b/scripts/guides/galaxies.py
@@ -46,6 +46,7 @@ These are documented fully in the `autogalaxy_workspace/*/guides/data_structures
 # from autoconf import setup_notebook; setup_notebook()
 
 import matplotlib.pyplot as plt
+import numpy as np
 from pathlib import Path
 import autofit as af
 import autogalaxy as ag
@@ -387,13 +388,14 @@ plt.show()
 plt.close()
 
 """
-If we want a specific 1D grid of a certain length over a certain range of coordinates, we can manually input a `Grid1D`
-object.
+If we want a specific 1D radial profile over a certain range of coordinates, we create a `Grid2DIrregular` of
+(y,x) coordinates along the x-axis and evaluate the image on it.
 """
-grid_1d = ag.Grid1D.uniform_from_zero(shape_native=(10000,), pixel_scales=0.01)
-image_1d = galaxy_0.image_2d_from(grid=grid_1d)
+radii = np.arange(10000) * 0.01
+grid_radial = ag.Grid2DIrregular(values=[(0.0, r) for r in radii])
+image_1d = galaxy_0.image_2d_from(grid=grid_radial)
 
-plt.plot(grid_1d, image_1d)
+plt.plot(radii, image_1d)
 plt.xlabel("Radius (arcseconds)")
 plt.ylabel("Luminosity")
 plt.show()

--- a/scripts/guides/plot/examples/plotters.py
+++ b/scripts/guides/plot/examples/plotters.py
@@ -37,6 +37,7 @@ To illustrate plotting, we require standard objects like a grid, dataset and fit
 
 import matplotlib.pyplot as plt
 import math
+import numpy as np
 
 from pathlib import Path
 import autogalaxy as ag
@@ -217,13 +218,13 @@ plt.show()
 plt.close()
 
 """
-Using a `Grid1D` which does not start from 0.0" plots the 1D quantity with both negative and positive radial
-coordinates.
+Using a radial grid of (y,x) coordinates along the x-axis plots the 1D radial profile.
 """
-grid_1d = ag.Grid1D.uniform_from_zero(shape_native=(10000,), pixel_scales=0.01)
-image_1d = galaxy_0.image_2d_from(grid=grid_1d)
+radii = np.arange(10000) * 0.01
+grid_radial = ag.Grid2DIrregular(values=[(0.0, r) for r in radii])
+image_1d = galaxy_0.image_2d_from(grid=grid_radial)
 
-plt.plot(grid_1d, image_1d)
+plt.plot(radii, image_1d)
 plt.xlabel("Radius (arcseconds)")
 plt.ylabel("Luminosity")
 plt.show()


### PR DESCRIPTION
## Summary

PR #28 was merged to \`release\` instead of \`main\` — its commit is on \`origin/release\` but absent from \`origin/main\`. Would be overwritten by the next \`main → release\` sync.

This PR cherry-picks it onto \`main\`.

## Scripts Changed
- \`a424e8a\` — refactor: replace Grid1D with Grid2DIrregular (PR #28)

## Root Cause

GitHub default branch on this repo is set to \`release\`, so PRs opened without an explicit \`--base main\` land on \`release\`. The \`/ship_workspace\` skill has been patched to always pass \`--base main\` explicitly. The repo default branch should also be changed back to \`main\`.

## Test Plan
- [x] Cherry-pick applied cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)