### PR TITLE
Remove PySwarms and UltraNest references

### DIFF
--- a/CITATIONS.rst
+++ b/CITATIONS.rst
@@ -14,7 +14,7 @@ our GitHub page!
 **PyAutoGalaxy** is published in the `Journal of Open Source Software <https://joss.theoj.org/papers/10.21105/joss.02825#>`_ and its
 entry in the above .bib file is under the citation key ``pyautogalaxy``.
 
-You should also specify the non-linear search(es) you use in your analysis (e.g. Dynesty, Emcee, PySwarms, etc) in
+You should also specify the non-linear search(es) you use in your analysis (e.g. Dynesty, Emcee, etc) in
 the main body of text, and delete as appropriate any packages your analysis did not use. The citations.bib file includes
 the citation key for all of these projects.
 

--- a/config/non_linear/README.rst
+++ b/config/non_linear/README.rst
@@ -6,4 +6,4 @@ Files
 
 - ``mcmc.yaml``: Settings default behaviour of MCMC non-linear searches (e.g. Emcee).
 - ``nest.yaml``: Settings default behaviour of nested sampler non-linear searches (e.g. Dynesty).
-- ``mle.yaml``: Settings default behaviour of maximum likelihood estimator (mle) searches (e.g. PySwarms).
+- ``mle.yaml``: Settings default behaviour of maximum likelihood estimator (mle) searches (e.g. LBFGS).

--- a/notebooks/howtogalaxy/chapter_optional/tutorial_searches.ipynb
+++ b/notebooks/howtogalaxy/chapter_optional/tutorial_searches.ipynb
@@ -330,8 +330,8 @@
         "__MCMC__\n",
         "\n",
         "For users familiar with Markov Chain Monte Carlo (MCMC) non-linear samplers, PyAutoFit supports the non-linear\n",
-        "searches `Emcee` and `Zeus`. Like PySwarms, these also need a good starting point, and are generally less effective at \n",
-        "modeling than Nautilus. \n",
+        "searches `Emcee` and `Zeus`. Like LBFGS, these also need a good starting point, and are generally less effective at\n",
+        "modeling than Nautilus.\n",
         "\n",
         "I've included an example runs of Emcee and Zeus below, where the model is set up using `UniformPriors` to give\n",
         "the starting point of the MCMC walkers. "

--- a/scripts/howtogalaxy/chapter_optional/tutorial_searches.py
+++ b/scripts/howtogalaxy/chapter_optional/tutorial_searches.py
@@ -215,8 +215,8 @@ setup of initialization priors.
 __MCMC__
 
 For users familiar with Markov Chain Monte Carlo (MCMC) non-linear samplers, PyAutoFit supports the non-linear
-searches `Emcee` and `Zeus`. Like PySwarms, these also need a good starting point, and are generally less effective at 
-modeling than Nautilus. 
+searches `Emcee` and `Zeus`. Like LBFGS, these also need a good starting point, and are generally less effective at
+modeling than Nautilus.
 
 I've included an example runs of Emcee and Zeus below, where the model is set up using `UniformPriors` to give
 the starting point of the MCMC walkers. 


### PR DESCRIPTION
## Summary
- Remove PySwarms and UltraNest references — these searches are no longer supported in PyAutoFit
- Strip scripts, notebooks, READMEs, config entries, tutorial prose, and citation lines that pointed users at broken examples
- The developer workspace is untouched (it intentionally preserves the legacy implementations)

## Test plan
- [ ] Grep sweep returns 0 hits for `pyswarm|ultranest` outside generated logs and `autofit_workspace_developer`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)