### PR TITLE
fix: enable fits_make / png_make smoke tests

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -31,3 +31,11 @@ overrides:
   # non-empty aggregator. Covers all scripts under guides/results/.
   - pattern: "guides/results/"
     unset: [PYAUTO_TEST_MODE, PYAUTO_SKIP_FIT_OUTPUT]
+  # fits_make / png_make produce .fits / .png outputs from real fits, so they need
+  # visualization turned on AND PYAUTO_FAST_PLOTS turned off (the latter would
+  # close every figure without saving via the subplot_save / save_figure short-circuit
+  # in autoarray/plot/utils.py).
+  - pattern: fits_make
+    unset: [PYAUTO_SKIP_VISUALIZATION, PYAUTO_FAST_PLOTS]
+  - pattern: png_make
+    unset: [PYAUTO_SKIP_VISUALIZATION, PYAUTO_FAST_PLOTS]

--- a/scripts/guides/results/workflow/csv_make.py
+++ b/scripts/guides/results/workflow/csv_make.py
@@ -119,12 +119,20 @@ for i in range(2):
 
     model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
 
+    """
+    __N Like Max__
+
+    `n_like_max=300` caps the search at 300 likelihood evaluations so this workflow example runs in
+    seconds and produces the .csv files it demonstrates without waiting for a full Nautilus
+    convergence. Remove the cap (or raise it substantially) for a real model fit.
+    """
     search = af.Nautilus(
         path_prefix=Path("results_folder_csv_png_fits"),
         name="results",
         unique_tag=f"simple_{i}",
         n_live=100,
         n_batch=50,
+        n_like_max=300,  # samples capped for quick result generation
     )
 
     class AnalysisLatent(ag.AnalysisImaging):

--- a/scripts/guides/results/workflow/fits_make.py
+++ b/scripts/guides/results/workflow/fits_make.py
@@ -130,12 +130,20 @@ for i in range(2):
 
     model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
 
+    """
+    __N Like Max__
+
+    `n_like_max=300` caps the search at 300 likelihood evaluations so this workflow example runs in
+    seconds and produces the .fits files it demonstrates without waiting for a full Nautilus
+    convergence. Remove the cap (or raise it substantially) for a real model fit.
+    """
     search = af.Nautilus(
         path_prefix=Path("results_folder_csv_png_fits"),
         name="results",
         unique_tag=f"simple_{i}",
         n_live=100,
         n_batch=50,
+        n_like_max=300,  # samples capped for quick result generation
     )
 
     class AnalysisLatent(ag.AnalysisImaging):

--- a/scripts/guides/results/workflow/png_make.py
+++ b/scripts/guides/results/workflow/png_make.py
@@ -135,12 +135,20 @@ for i in range(2):
 
     model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
 
+    """
+    __N Like Max__
+
+    `n_like_max=300` caps the search at 300 likelihood evaluations so this workflow example runs in
+    seconds and produces the .png files it demonstrates without waiting for a full Nautilus
+    convergence. Remove the cap (or raise it substantially) for a real model fit.
+    """
     search = af.Nautilus(
         path_prefix=Path("results_folder_csv_png_fits"),
         name="results",
         unique_tag=f"simple_{i}",
         n_live=100,
         n_batch=50,
+        n_like_max=300,  # samples capped for quick result generation
     )
 
     class AnalysisLatent(ag.AnalysisImaging):


### PR DESCRIPTION
## Summary

Smoke tests run with `PYAUTO_SKIP_VISUALIZATION=1` and `PYAUTO_FAST_PLOTS=1`. The latter short-circuits `subplot_save` / `save_figure` in `autoarray/plot/utils.py` and closes every figure without writing it, so `fits_make` / `png_make` had nothing for the aggregator to extract and were skipped via `no_run.yaml` in PyAutoBuild.

This PR overrides both env vars for the `fits_make` / `png_make` patterns and caps Nautilus at `n_like_max=300` in the three workflow examples so they finish in seconds.

## Scripts Changed

- `config/build/env_vars.yaml` — add overrides for `fits_make` / `png_make` patterns that `unset: [PYAUTO_SKIP_VISUALIZATION, PYAUTO_FAST_PLOTS]`
- `scripts/guides/results/workflow/csv_make.py` — add `n_like_max=300` (with inline comment + `__N Like Max__` docstring section)
- `scripts/guides/results/workflow/fits_make.py` — same
- `scripts/guides/results/workflow/png_make.py` — same

## Upstream PR

https://github.com/PyAutoLabs/PyAutoBuild/pull/60 — companion PyAutoBuild PR that drops `fits_make` / `png_make` from `no_run.yaml`.

## Test Plan

- [x] Manually ran `csv_make.py` / `fits_make.py` / `png_make.py` in the worktree with the resolved env — all three produce expected outputs at `output/results_folder_csv_png_fits/workflow_make_example/`.
- [ ] Smoke tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)