### PR TITLE
docs: update stale admin_jammy/prompt/ refs to PyAutoPrompt/

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -31,11 +31,11 @@
 - png_make # Test mode does not output .png images.
 - examples/searches # Test mode breaks search visualization.
 - data_fitting # Test mode breaks .fits file output
-- ellipse/simulator # NEEDS_FIX 2026-04-24 - all ellipse examples parked pending JAX refactor; see admin_jammy/prompt/autogalaxy/ellipse_no_run.md
-- ellipse/fit # NEEDS_FIX 2026-04-24 - all ellipse examples parked pending JAX refactor; see admin_jammy/prompt/autogalaxy/ellipse_no_run.md
-- ellipse/modeling # NEEDS_FIX 2026-04-24 - all ellipse examples parked pending JAX refactor; see admin_jammy/prompt/autogalaxy/ellipse_no_run.md
-- ellipse/multipoles # NEEDS_FIX 2026-04-24 - all ellipse examples parked pending JAX refactor; see admin_jammy/prompt/autogalaxy/ellipse_no_run.md
-- ellipse/database # NEEDS_FIX 2026-04-24 - all ellipse examples parked pending JAX refactor; see admin_jammy/prompt/autogalaxy/ellipse_no_run.md
+- ellipse/simulator # NEEDS_FIX 2026-04-24 - all ellipse examples parked pending JAX refactor; see PyAutoPrompt/autogalaxy/ellipse_no_run.md
+- ellipse/fit # NEEDS_FIX 2026-04-24 - all ellipse examples parked pending JAX refactor; see PyAutoPrompt/autogalaxy/ellipse_no_run.md
+- ellipse/modeling # NEEDS_FIX 2026-04-24 - all ellipse examples parked pending JAX refactor; see PyAutoPrompt/autogalaxy/ellipse_no_run.md
+- ellipse/multipoles # NEEDS_FIX 2026-04-24 - all ellipse examples parked pending JAX refactor; see PyAutoPrompt/autogalaxy/ellipse_no_run.md
+- ellipse/database # NEEDS_FIX 2026-04-24 - all ellipse examples parked pending JAX refactor; see PyAutoPrompt/autogalaxy/ellipse_no_run.md
 - imaging/data_preparation/manual/mask_irregular # NEEDS_FIX 2026-04-10 - silent failure, needs investigation
 - imaging/features/pixelization/modeling # NEEDS_FIX 2026-04-10 - LinAlgError: matrix not positive definite in pixelization modeling
 - autogalaxy_workspace/scripts/imaging/modeling # NEEDS_FIX 2026-04-10 - KeyError on ('galaxies','galaxy','bulge','ell_comps'...) kwargs after API drift in top-level imaging/modeling.py


### PR DESCRIPTION
## Summary

The PyAuto prompt registry was moved from `admin_jammy/prompt/` to `PyAutoPrompt/` on 2026-04-27. This PR updates stale comment / docstring / YAML / Markdown references in this repo to point at the new location.

## Files Changed

- `config/build/no_run.yaml` — 5 YAML comment lines pointing at the ellipse-fitting follow-up prompt updated

## Test Plan

- [x] Pure text-substitution edits — comments, docstrings, YAML comments, Markdown text only
- [x] Zero runtime behavior change; no executable code paths modified
- [N/A] Smoke tests skipped — not justified for comment-only edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)