### PR TITLE
fix: replace removed aplt.LightProfile plotter in welcome.py

### DIFF
--- a/welcome.py
+++ b/welcome.py
@@ -82,10 +82,7 @@ sersic_light_profile = ag.lp.Exponential(
     centre=(0.3, 0.2), ell_comps=(0.2, 0.0), intensity=0.05, effective_radius=1.0
 )
 
-light_profile_plotter = aplt.LightProfile(
-    light_profile=sersic_light_profile, grid=grid
-)
-light_profile_plotter.figures_2d(image=True)
+aplt.plot_array(array=sersic_light_profile.image_2d_from(grid=grid), title="Image")
 
 input(
     "\n"


### PR DESCRIPTION
## Summary
`welcome.py` crashed with `AttributeError: module 'autogalaxy.plot' has
no attribute 'LightProfile'` because the `LightProfile` plotter class is
no longer part of the `autogalaxy.plot` API. Replace the four-line
plotter construction + `figures_2d(image=True)` call with a single
`aplt.plot_array(array=light_profile.image_2d_from(grid=grid), ...)` —
matching the pattern already used in `autolens_workspace/welcome.py`.

## Scripts Changed
- `welcome.py` — replaced `aplt.LightProfile(...)` + `figures_2d(image=True)` with `aplt.plot_array(array=sersic_light_profile.image_2d_from(grid=grid), title="Image")`

## Test Plan
- [x] `yes "" | python welcome.py` runs to completion (exit 0)
- [x] Smoke tests pass

Refs Jammy2211/autolens_workspace#108

🤖 Generated with [Claude Code](https://claude.com/claude-code)