### PR TITLE
feat(python-version): support Python 3.9-3.14, first-class 3.12/3.13

### DIFF
--- a/config/general.yaml
+++ b/config/general.yaml
@@ -1,4 +1,8 @@
 
+# version:
+#   python_version_check: False  # uncomment to suppress the Python version warning
+#                                # if running on a non-recommended Python (anything other than 3.12 / 3.13).
+
 updates:
   iterations_per_quick_update: 1e99 # Non-linear search iterations between every quick update, which just displays the maximum likelihood model fit.
   iterations_per_full_update: 1e99  # Non-linear search iterations between every full update, which outputs all visuals and result fits (e.g. model.result, search.summary), this exits the search and can be slow.  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-autogalaxy
+autogalaxy[jax]
 numba


### PR DESCRIPTION
## Summary

Workspace-side updates for the Python version policy change supporting Python 3.9–3.14.

## Changes in this repo

- `requirements.txt`: switched from `autogalaxy` to `autogalaxy[jax]` so JAX features remain installed by default on Python 3.11+. On 3.9/3.10 the extra silently resolves to nothing (the JAX entries in `autogalaxy`'s `optional-dependencies` are gated on `python_version >= '3.11'`).
- `config/general.yaml`: added a commented `version: python_version_check: False` block at the top, documenting the bypass for users running on a non-recommended Python version.

## Test plan

- [x] Smoke tests pass on Python 3.12 (current)
- [ ] Autobuild matrix workflow verifies on 3.9–3.14

This is one of 12 coordinated PRs. See sibling PRs on `feature/python-version-policy` in the libraries (PyAutoConf, etc.) and the other workspaces.