### PR TITLE
Drop removed plot_grid kwarg; emit extra_galaxies_centres.json from simulator

### DIFF
--- a/scripts/guides/advanced/over_sampling.py
+++ b/scripts/guides/advanced/over_sampling.py
@@ -98,18 +98,17 @@ print(grid_sub_1.over_sampled.shape)
 print(grid_sub_2.over_sampled.shape)
 
 """
-We now plot the over sampled grid over the image, showing that each pixel is now split into a 2x2 sub-grid of 
-coordinates. 
+We now plot the over sampled grid, showing that each pixel is split into a 2x2 sub-grid of coordinates.
 
-These are used to compute the intensity of the light profile and therefore more accurately estimate the total 
+These are used to compute the intensity of the light profile and therefore more accurately estimate the total
 intensity within each pixel if there is a significant gradient in intensity within the pixel.
 
-In the code below, it is the input `plot_over_sampled_grid=True` which ensures we plot the over sampled grid.
+In the code below, we pass `grid_sub_2.over_sampled` directly to `aplt.plot_grid`, which scatters every
+sub-pixel coordinate so the 2x2 sub-grid pattern is visible.
 """
 aplt.plot_grid(
-    grid=grid_sub_2,
+    grid=grid_sub_2.over_sampled,
     title="Grid With 2x2 Over-Sampling",
-    plot_over_sampled_grid=True,
 )
 
 """
@@ -261,9 +260,8 @@ grid_adaptive = ag.Grid2D.no_mask(
 )
 
 aplt.plot_grid(
-    grid=grid_adaptive,
+    grid=grid_adaptive.over_sampled,
     title="Adaptive Over-Sampling",
-    plot_over_sampled_grid=True,
 )
 
 print(over_sample_size)
@@ -287,9 +285,8 @@ over_sample_size = ag.util.over_sample.over_sample_size_via_radial_bins_from(
 grid_adaptive = ag.Grid2D(values=grid, mask=mask, over_sample_size=over_sample_size)
 
 aplt.plot_grid(
-    grid=grid_adaptive,
+    grid=grid_adaptive.over_sampled,
     title="Adaptive Over-Sampling",
-    plot_over_sampled_grid=True,
 )
 
 """

--- a/scripts/imaging/features/extra_galaxies/simulator.py
+++ b/scripts/imaging/features/extra_galaxies/simulator.py
@@ -255,13 +255,29 @@ aplt.fits_array(
 __Plane Output__
 
 Save the `Galaxies` in the dataset folder as a .json file, ensuring the true light profiles and galaxies
-are safely stored and available to check how the dataset was simulated in the future. 
+are safely stored and available to check how the dataset was simulated in the future.
 
 This can be loaded via the method `galaxies = ag.from_json()`.
 """
 ag.output_to_json(
     obj=galaxies,
     file_path=Path(dataset_path, "galaxies.json"),
+)
+
+"""
+__Extra Galaxies Centres__
+
+Save the (y,x) centres of the two extra galaxies as a `Grid2DIrregular` JSON file. The modeling tutorial
+`features/extra_galaxies/modeling.py` loads this file to fix or initialise the extra-galaxy light-profile
+centres. The data-preparation tutorial `data_preparation/examples/optional/extra_galaxies_centres.py`
+demonstrates how a user would mark these centres themselves on real data.
+"""
+extra_galaxies_centres = ag.Grid2DIrregular(
+    values=[extra_galaxy_0_centre, extra_galaxy_1_centre]
+)
+ag.output_to_json(
+    obj=extra_galaxies_centres,
+    file_path=Path(dataset_path, "extra_galaxies_centres.json"),
 )
 
 """


### PR DESCRIPTION
## Summary
- **Item 1** — `over_sampling.py` (3 call sites): drop the `plot_over_sampled_grid=True` kwarg from `aplt.plot_grid` (PyAutoArray removed it in `b491a119`). Pass `grid.over_sampled` directly as the grid argument so the tutorial still shows the over-sampled scatter.
- **Item 8** — `extra_galaxies/simulator.py`: emit `extra_galaxies_centres.json` so `modeling.py` (and the auto-sim block on line 87) gets a complete dataset on first run, without depending on the optional `data_preparation/.../extra_galaxies_centres.py` step.

## Scripts Changed
- `scripts/guides/advanced/over_sampling.py` — replace removed `plot_over_sampled_grid` kwarg with `.over_sampled` direct grid input (3 sites + prose)
- `scripts/imaging/features/extra_galaxies/simulator.py` — add `extra_galaxies_centres.json` output

## Why now
Triage Cluster F (release-prep run 2026-04-29):
- `over_sampling.py` failed with `TypeError: plot_grid() got an unexpected keyword argument 'plot_over_sampled_grid'`.
- `extra_galaxies/modeling.py` failed with `FileNotFoundError: extra_galaxies_centres.json`.

## Test plan
- [x] `over_sampling.py` runs to completion under `PYAUTO_TEST_MODE=2` (3 plots produce over-sampled scatter)
- [x] `extra_galaxies/modeling.py` runs after deleting the dataset (auto-sim regenerates with the new centres JSON)
- [x] Workspace smoke tests (6/6) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)