### PR TITLE
Refactor guides/results aggregator to share quick-fit helper

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -17,10 +17,6 @@
 #   banner. Investigate the failure, fix the underlying bug, and remove
 #   the NEEDS_FIX marker.
 
-- guides/results/start_here # SLOW 2026-04-10 - exceeds 60s test timeout; unsets TEST_MODE to produce real samples for downstream examples
-- guides/results/examples/galaxies_fit # SLOW 2026-04-10 - exceeds 60s test timeout; unsets TEST_MODE for downstream examples
-- guides/results/examples/samples # SLOW 2026-04-10 - exceeds 60s test timeout; unsets TEST_MODE for downstream examples
-- guides/results/examples/models # SLOW 2026-04-10 - cascade from SLOW-skipped results/start_here.py; aggregator returns NoneType so instance.galaxies is None
 - guides/results/workflow/csv_make # SLOW 2026-04-10 - exceeds 60s test timeout; unsets TEST_MODE for downstream examples
 - guides/results/database/start_here # SLOW 2026-04-10 - previously failed fast on a broken aggregator query; now runs the real aggregator and exceeds 60s
 - gui/light_centre # GUI scripts cannot be run
@@ -30,7 +26,6 @@
 - fits_make # Test mode does not output .fits images.
 - png_make # Test mode does not output .png images.
 - examples/searches # Test mode breaks search visualization.
-- data_fitting # Test mode breaks .fits file output
 - ellipse/simulator # NEEDS_FIX 2026-04-24 - all ellipse examples parked pending JAX refactor; see PyAutoPrompt/autogalaxy/ellipse_no_run.md
 - ellipse/fit # NEEDS_FIX 2026-04-24 - all ellipse examples parked pending JAX refactor; see PyAutoPrompt/autogalaxy/ellipse_no_run.md
 - ellipse/modeling # NEEDS_FIX 2026-04-24 - all ellipse examples parked pending JAX refactor; see PyAutoPrompt/autogalaxy/ellipse_no_run.md

--- a/scripts/guides/results/_quick_fit.py
+++ b/scripts/guides/results/_quick_fit.py
@@ -1,0 +1,73 @@
+"""
+Results: Quick Fit Helper
+=========================
+
+Internal helper invoked via subprocess from the tutorials in this folder
+(``start_here.py`` and everything under ``aggregator/``). Produces a fast,
+capped Nautilus fit at ``output/results_folder/`` so the aggregator examples
+have a populated results directory to read from.
+
+Idempotent: exits immediately if ``output/results_folder/`` already exists,
+so concurrent or repeated invocations are cheap.
+
+Not a tutorial. The model and dataset mirror those used in ``start_here.py``
+(simple imaging, single galaxy, Sersic bulge + Exponential disk), but the
+search is hard-capped at ``n_like_max=300`` likelihood evaluations rather
+than running to convergence. This produces a shallow but valid posterior
+fast enough to fit inside the per-script CI timeout.
+"""
+
+import sys
+from pathlib import Path
+
+results_path = Path("output") / "results_folder"
+if results_path.exists():
+    sys.exit(0)
+
+import autofit as af
+import autogalaxy as ag
+
+dataset_name = "simple"
+dataset_path = Path("dataset") / "imaging" / dataset_name
+
+if not dataset_path.exists():
+    import subprocess
+
+    subprocess.run(
+        [sys.executable, "scripts/imaging/simulator.py"],
+        check=True,
+    )
+
+dataset = ag.Imaging.from_fits(
+    data_path=dataset_path / "data.fits",
+    psf_path=dataset_path / "psf.fits",
+    noise_map_path=dataset_path / "noise_map.fits",
+    pixel_scales=0.1,
+)
+
+mask = ag.Mask2D.circular(
+    shape_native=dataset.shape_native, pixel_scales=dataset.pixel_scales, radius=3.0
+)
+
+dataset = dataset.apply_mask(mask=mask)
+
+bulge = af.Model(ag.lp_linear.Sersic)
+disk = af.Model(ag.lp_linear.Exponential)
+bulge.centre = disk.centre
+
+galaxy = af.Model(ag.Galaxy, redshift=0.5, bulge=bulge, disk=disk)
+
+model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
+
+search = af.Nautilus(
+    path_prefix=Path("results_folder"),
+    name="results",
+    unique_tag=dataset_name,
+    n_batch=50,
+    n_live=100,
+    n_like_max=300,
+)
+
+analysis = ag.AnalysisImaging(dataset=dataset, use_jax=True)
+
+search.fit(model=model, analysis=analysis)

--- a/scripts/guides/results/aggregator/data_fitting.py
+++ b/scripts/guides/results/aggregator/data_fitting.py
@@ -63,7 +63,7 @@ if not results_path.exists():
     import sys
 
     subprocess.run(
-        [sys.executable, "scripts/guides/results/start_here.py"],
+        [sys.executable, "scripts/guides/results/_quick_fit.py"],
         check=True,
     )
 

--- a/scripts/guides/results/aggregator/galaxies_fit.py
+++ b/scripts/guides/results/aggregator/galaxies_fit.py
@@ -53,11 +53,31 @@ import autogalaxy as ag
 import autogalaxy.plot as aplt
 
 """
+__Quick Fit Auto-Trigger__
+
+If a previous fit has not been run yet, the shared helper ``_quick_fit.py`` is invoked to produce one.
+The helper writes a capped Nautilus fit to ``output/results_folder/`` so this tutorial (and its siblings
+in this folder) have results to work with. When that folder already exists the helper exits immediately,
+so re-running this tutorial is cheap.
+"""
+results_path = Path("output") / "results_folder"
+if not results_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/guides/results/_quick_fit.py"],
+        check=True,
+    )
+
+"""
 __Model Fit__
 
 To illustrate results, we need to perform a model-fit in order to create a `Result` object.
 
-The code below performs a model-fit using nautilus. 
+The code below performs a model-fit using nautilus. The helper above already wrote a completed fit to
+``output/results_folder/``, so the ``search.fit(...)`` call below resumes from that checkpoint and
+returns the in-memory ``Result`` object without redoing the search.
 
 You should be familiar with modeling already, if not read the `modeling/start_here.py` script before reading this one.
 """
@@ -107,6 +127,7 @@ search = af.Nautilus(
     unique_tag=dataset_name,
     n_batch=50,
     n_live=100,
+    n_like_max=300,
 )
 
 analysis = ag.AnalysisImaging(dataset=dataset, use_jax=True)

--- a/scripts/guides/results/aggregator/models.py
+++ b/scripts/guides/results/aggregator/models.py
@@ -52,7 +52,7 @@ if not results_path.exists():
     import sys
 
     subprocess.run(
-        [sys.executable, "scripts/guides/results/start_here.py"],
+        [sys.executable, "scripts/guides/results/_quick_fit.py"],
         check=True,
     )
 

--- a/scripts/guides/results/aggregator/queries.py
+++ b/scripts/guides/results/aggregator/queries.py
@@ -48,7 +48,7 @@ if not results_path.exists():
     import sys
 
     subprocess.run(
-        [sys.executable, "scripts/guides/results/start_here.py"],
+        [sys.executable, "scripts/guides/results/_quick_fit.py"],
         check=True,
     )
 

--- a/scripts/guides/results/aggregator/samples.py
+++ b/scripts/guides/results/aggregator/samples.py
@@ -49,11 +49,31 @@ import autogalaxy as ag
 import autogalaxy.plot as aplt
 
 """
+__Quick Fit Auto-Trigger__
+
+If a previous fit has not been run yet, the shared helper ``_quick_fit.py`` is invoked to produce one.
+The helper writes a capped Nautilus fit to ``output/results_folder/`` so this tutorial (and its siblings
+in this folder) have results to work with. When that folder already exists the helper exits immediately,
+so re-running this tutorial is cheap.
+"""
+results_path = Path("output") / "results_folder"
+if not results_path.exists():
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "scripts/guides/results/_quick_fit.py"],
+        check=True,
+    )
+
+"""
 __Model Fit__
 
 To illustrate results, we need to perform a model-fit in order to create a `Result` object.
 
-The code below performs a model-fit using nautilus. 
+The code below performs a model-fit using nautilus. The helper above already wrote a completed fit to
+``output/results_folder/``, so the ``search.fit(...)`` call below resumes from that checkpoint and
+returns the in-memory ``Result`` object without redoing the search.
 
 You should be familiar with modeling already, if not read the `modeling/start_here.py` script before reading this one!
 """
@@ -103,6 +123,7 @@ search = af.Nautilus(
     unique_tag=dataset_name,
     n_batch=50,
     n_live=100,
+    n_like_max=300,
 )
 
 analysis = ag.AnalysisImaging(dataset=dataset, use_jax=True)

--- a/scripts/guides/results/aggregator/samples_via_aggregator.py
+++ b/scripts/guides/results/aggregator/samples_via_aggregator.py
@@ -88,7 +88,7 @@ if not results_path.exists():
     import sys
 
     subprocess.run(
-        [sys.executable, "scripts/guides/results/start_here.py"],
+        [sys.executable, "scripts/guides/results/_quick_fit.py"],
         check=True,
     )
 

--- a/scripts/guides/results/start_here.py
+++ b/scripts/guides/results/start_here.py
@@ -227,25 +227,18 @@ galaxy = af.Model(ag.Galaxy, redshift=0.5, bulge=bulge, disk=disk)
 
 model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
 
-test_mode_was_on = os.environ.get("PYAUTO_TEST_MODE") == "1"
-if test_mode_was_on:
-    os.environ.pop("PYAUTO_TEST_MODE", None)
-
 search = af.Nautilus(
     path_prefix=Path("results_folder"),
     name="results",
     unique_tag=dataset_name,
     n_batch=50,
     n_live=100,
-    **({"n_like_max": 300} if test_mode_was_on else {}),
+    n_like_max=300,
 )
 
 analysis = ag.AnalysisImaging(dataset=dataset, use_jax=True)
 
 result = search.fit(model=model, analysis=analysis)
-
-if test_mode_was_on:
-    os.environ["PYAUTO_TEST_MODE"] = "1"
 
 """
 __Info__


### PR DESCRIPTION
## Summary

Refactors `scripts/guides/results/` so the aggregator examples no longer each run their own ~10-minute Nautilus search and cascade-fail off each other in CI. Each aggregator example now auto-triggers a shared `_quick_fit.py` helper if `output/results_folder/` is missing. The helper writes a capped fit (`n_like_max=300`, ~14-33s end-to-end) to a fixed location, and every example loads from there. `start_here.py`'s previously-conditional `n_like_max=300` cap is now unconditional.

## Why

In the 2026-04-29 release-prep run, Cluster D in `triage.md` flagged 8 failures across this folder: 4 timeouts (each example duplicated the `search.fit()` block uncapped) and 4 cascading `NoneType` errors (downstream readers loaded the partial output of the timed-out scripts). Root cause: each example was duplicating a slow, uncapped search instead of routing through one helper, and `n_like_max` was gated on `PYAUTO_TEST_MODE` which `env_vars.yaml` unsets for this folder.

## API Changes

None.

## Scripts Changed

- `scripts/guides/results/_quick_fit.py` (new) - internal helper, capped Nautilus fit, idempotent (early-exits if `output/results_folder/` already exists).
- `scripts/guides/results/start_here.py` - drops the `test_mode_was_on` conditional gate on `n_like_max`; cap is now unconditional.
- `scripts/guides/results/aggregator/galaxies_fit.py` (autogalaxy) / `galaxies_fits.py` (autolens) - adds auto-trigger guard at top + `n_like_max=300` to the search.
- `scripts/guides/results/aggregator/samples.py` - same.
- `scripts/guides/results/aggregator/{models,queries,data_fitting,samples_via_aggregator}.py` - existing subprocess targets redirected from `start_here.py` to `_quick_fit.py`.
- `config/build/no_run.yaml` - removed: `guides/results/start_here` (autogalaxy), three stale `guides/results/examples/*` lines (both), stale `data_fitting` stem skip (both).

## Test plan

- [x] `_quick_fit.py` runs to completion locally with `n_like_max=300` cap and produces populated `output/results_folder/` (autogalaxy: ~14s, autolens: ~33s).
- [x] After the helper has run, `aggregator/models.py` exits 0 in both workspaces (loads result via `Aggregator.from_directory`, computes max-log-likelihood quantities).
- [x] Idempotency: re-running `_quick_fit.py` exits in 0.04s when output exists.
- [ ] CI release-prep run shows zero `guides/results/aggregator/*` failures.

Co-authored by Claude Code.