### PR TITLE
Cluster E: fix guides/plot/start_here.py auto-simulate target

### DIFF
--- a/scripts/guides/plot/start_here.py
+++ b/scripts/guides/plot/start_here.py
@@ -40,7 +40,7 @@ if not dataset_path.exists():
     import sys
 
     subprocess.run(
-        [sys.executable, "scripts/guides/plot/simulator.py"],
+        [sys.executable, "scripts/imaging/simulator.py"],
         check=True,
     )
 


### PR DESCRIPTION
## Summary

Fixes the 5th failure in Cluster E from the 2026-04-29 release-prep triage. `scripts/guides/plot/start_here.py` already had the canonical auto-simulate snippet, but the snippet's subprocess target was wrong: it called `scripts/guides/plot/simulator.py` (which writes `dataset/imaging/sersic_x2/`) when the script reads `dataset/imaging/simple/`. Re-target it at `scripts/imaging/simulator.py`, which is the simulator that actually emits `dataset/imaging/simple/`.

## Scripts Changed

- `scripts/guides/plot/start_here.py` — change auto-simulate subprocess target from `scripts/guides/plot/simulator.py` to `scripts/imaging/simulator.py`.

## Test Plan

- [x] Script runs to exit 0 from a wiped `dataset/imaging/simple/` state under `PYAUTO_SMALL_DATASETS=1 PYAUTO_TEST_MODE=1 PYAUTO_FAST_PLOTS=1`
- [x] `dataset/imaging/simple/data.fits` is created by the simulator subprocess
- [ ] Smoke tests pass for the affected workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)