### PR TITLE
fix: neutralize smoke-mode env vars in _quick_fit.py helper

### DIFF
--- a/scripts/guides/results/_quick_fit.py
+++ b/scripts/guides/results/_quick_fit.py
@@ -24,6 +24,18 @@ results_path = Path("output") / "results_folder"
 if results_path.exists():
     sys.exit(0)
 
+import os
+
+# The aggregator tutorials that invoke this helper read image/dataset.fits via
+# fit.value("dataset"). Smoke-mode env vars (PYAUTO_TEST_MODE>=2,
+# PYAUTO_SKIP_VISUALIZATION) suppress the visualizer that writes that file, so
+# neutralize them here.
+mode = os.environ.get("PYAUTO_TEST_MODE", "0")
+if mode in ("2", "3"):
+    os.environ["PYAUTO_TEST_MODE"] = "1"
+os.environ.pop("PYAUTO_SKIP_VISUALIZATION", None)
+os.environ.pop("PYAUTO_SKIP_FIT_OUTPUT", None)
+
 import autofit as af
 import autogalaxy as ag
 


### PR DESCRIPTION
## Summary
Four aggregator tutorial scripts (`scripts/guides/results/aggregator/data_fitting.py` and `models.py` in both `autogalaxy_workspace` and `autolens_workspace`) crash with `TypeError: 'NoneType' object is not subscriptable` at `PyAutoGalaxy/autogalaxy/aggregator/agg_util.py:101` when run in fast smoke mode (`PYAUTO_TEST_MODE=2 PYAUTO_SKIP_VISUALIZATION=1`). The `_quick_fit.py` helper they invoke via subprocess inherits those env vars and skips the visualizer that writes `image/dataset.fits`, so the downstream `fit.value("dataset")` call returns `None`.

This was Cluster A of the recent release-prep triage. The companion fix in `autolens_workspace` carries identical changes.

## Scripts Changed
- `scripts/guides/results/_quick_fit.py` — pop `PYAUTO_SKIP_VISUALIZATION` and `PYAUTO_SKIP_FIT_OUTPUT`, downgrade `PYAUTO_TEST_MODE>=2` to `1`, before importing `autofit`. Ensures the helper always produces a complete `output/results_folder/` (including `image/dataset.fits`) regardless of how the parent script was invoked. Idempotent early-exit means the cost is paid once per workspace per smoke run.

## Test Plan
- [ ] Smoke tests pass for affected workspace
- [x] Verified locally: aggregator `data_fitting.py` and `models.py` exit 0 under `PYAUTO_TEST_MODE=2 PYAUTO_SKIP_FIT_OUTPUT=1 PYAUTO_SKIP_VISUALIZATION=1 PYAUTO_SKIP_CHECKS=1 PYAUTO_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1` (pre-fix: `data_fitting.py` exits 1 with the documented `TypeError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)