### PR TITLE
fix: correct HDU indices for dataset.fits reload in results/start_here.py

### DIFF
--- a/scripts/guides/results/start_here.py
+++ b/scripts/guides/results/start_here.py
@@ -230,9 +230,9 @@ if (image_path / "dataset.fits").exists():
         data_path=image_path / "dataset.fits",
         noise_map_path=image_path / "dataset.fits",
         psf_path=image_path / "dataset.fits",
-        data_hdu=0,
-        noise_map_hdu=1,
-        psf_hdu=2,
+        data_hdu=1,
+        noise_map_hdu=2,
+        psf_hdu=3,
         pixel_scales=0.1,
     )
 


### PR DESCRIPTION
## Summary
Fix HDU indices in the `dataset.fits` reload block of `scripts/guides/results/start_here.py`. The Simple-Loading section was passing `data_hdu=0, noise_map_hdu=1, psf_hdu=2`, but the visualizer writes `dataset.fits` with MASK at HDU 0 and the data / noise_map / psf triplet at HDUs 1 / 2 / 3. The off-by-one made `psf_hdu=2` pull the 100×100 noise map, which the `Convolver` rejected with `KernelException: "Convolver Convolver must be odd"`, crashing the script end-to-end.

## Scripts Changed
- `scripts/guides/results/start_here.py` — bumped `data_hdu` 0→1, `noise_map_hdu` 1→2, `psf_hdu` 2→3 in the FITS-reload block (lines 233–235) so the kwargs match the visualizer's actual HDU layout: `MASK, DATA, NOISE_MAP, PSF, OVER_SAMPLE_SIZE_LP, OVER_SAMPLE_SIZE_PIXELIZATION`.

## Test Plan
- [x] `PYAUTO_TEST_MODE=1 python scripts/guides/results/start_here.py` runs to completion from a clean `output/results_folder` (clean-fit case).
- [x] Same script re-run against the cached fit also runs to completion (resume case — exercises the patched `from_fits`).
- [x] Regression: `aggregator/{galaxies_fit,samples,samples_via_aggregator}.py` still pass.
- [x] `scripts/check_sizes.sh` reports "all scripts within size tolerance".

🤖 Generated with [Claude Code](https://claude.com/claude-code)