### PR TITLE
fix: pathlib-refactor leftovers in HPC example_cpu_and_gpu.py

### DIFF
--- a/scripts/guides/hpc/example_cpu_and_gpu.py
+++ b/scripts/guides/hpc/example_cpu_and_gpu.py
@@ -61,7 +61,7 @@ You will need to update `hpc_username` to your hpc username below.
 """
 from pathlib import Path
 
-hpc_output_path = Path(path.sep) / "hpc" / "data" / "hpc_username" / "output"
+hpc_output_path = Path("/") / "hpc" / "data" / "hpc_username" / "output"
 
 """
 __HPC Dataset Path__
@@ -79,7 +79,7 @@ dataset_folder = "example"
 dataset_name = "simple"
 
 hpc_dataset_path = (
-    Path(path.sep)
+    Path("/")
     / "hpc"
     / "data"
     / "hpc_username"
@@ -97,7 +97,7 @@ The home path often has signficant storage restrictions, so is not a good locati
 But may be where you store the python galaxy modeling scripts you run on the HPC, the config files, batch scripts
 and other files you use to set up galaxy modeling on the hpc.
 """
-home_path = Path(path.sep, "hpc", "home", "hpc_username")
+home_path = Path("/", "hpc", "home", "hpc_username")
 
 """
 On the HPC, most likely in your home directory, you should have a config folder which contains the config files used by
@@ -204,7 +204,7 @@ We now create the path to the dataset this specific job fits, for example:
 """
 dataset_path = Path(hpc_dataset_path, dataset_type, dataset_name)
 
-if not dataset_Path().exists():
+if not dataset_path.exists():
     local_dataset_path = Path.cwd()
     dataset_type = "imaging"
     dataset_path = Path(local_dataset_path, "dataset", dataset_type, dataset_name)
@@ -239,7 +239,7 @@ dataset_name = "simple"
 
 dataset_path = Path(hpc_dataset_path, dataset_folder, dataset_name)
 
-if not dataset_Path().exists():
+if not dataset_path.exists():
     local_dataset_path = Path.cwd()
     dataset_folder = "imaging"
     dataset_path = Path(local_dataset_path, "dataset", dataset_folder, dataset_name)
@@ -251,7 +251,7 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
-if not dataset_Path().exists():
+if not dataset_path.exists():
     import subprocess
     import sys
 


### PR DESCRIPTION
## Summary
Cluster H follow-up to #59 (the `os.path` → `pathlib` refactor). Two classes of leftover typos in `scripts/guides/hpc/example_cpu_and_gpu.py`, both produced by the same case-insensitive `path` → `Path` substitution:

1. **`Path(path.sep…)`** at lines 64, 82, 100 — `path` was the old `os.path` import, removed by #59. Execution died at line 64 with `NameError: name 'path' is not defined. Did you mean: 'Path'?`. Replaced with `Path("/" …)`; `pathlib` normalises `/` correctly on both POSIX and Windows, and the HPC scripts target SLURM-style absolute paths like `/hpc/data/...` which always begin with `/`.
2. **`dataset_Path()`** at lines 207, 242, 254 — the substitution corrupted the variable name `dataset_path` (defined at line 205 as a `Path` instance) into `dataset_Path`, then re-styled it as a callable. Replaced with `dataset_path` (no parens — it’s a `Path` instance, not a constructor).

Without #2 the script would only fail later at line 207 instead of line 64; both fixes are needed for the script to run end-to-end.

## Scripts Changed
- `scripts/guides/hpc/example_cpu_and_gpu.py` — three `Path(path.sep …)` → `Path("/" …)` at lines 64, 82, 100; three `dataset_Path()` → `dataset_path` at lines 207, 242, 254.

## Test Plan
- [x] `PYAUTO_TEST_MODE=1 python scripts/guides/hpc/example_cpu_and_gpu.py` runs to exit 0 (was `NameError: name 'path' is not defined` at line 64).
- [x] `grep -n "path\.sep\|dataset_Path" scripts/guides/hpc/` returns no matches in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)