### PR TITLE
docs: render __Contents__ blocks as Markdown lists

### DIFF
--- a/scripts/ellipse/database.py
+++ b/scripts/ellipse/database.py
@@ -20,12 +20,12 @@ especially if loading results from hard-disk is slow.
 
 __Contents__
 
-**Aggregator:** Setting up the SQLite database and aggregator for ellipse results.
-**Ellipses via Aggregator:** Loading maximum log likelihood ellipse objects from the database.
-**Fits via Aggregator:** Loading imaging datasets and FitEllipse objects from the database.
-**Visualization Customization:** Customizing plots of ellipse fits loaded via the aggregator.
-**Errors (Random draws from PDF):** Drawing random fits from the posterior to quantify errors.
-**Multipoles:** Loading and inspecting multipole model-fit results from the database.
+- **Aggregator:** Setting up the SQLite database and aggregator for ellipse results.
+- **Ellipses via Aggregator:** Loading maximum log likelihood ellipse objects from the database.
+- **Fits via Aggregator:** Loading imaging datasets and FitEllipse objects from the database.
+- **Visualization Customization:** Customizing plots of ellipse fits loaded via the aggregator.
+- **Errors (Random draws from PDF):** Drawing random fits from the posterior to quantify errors.
+- **Multipoles:** Loading and inspecting multipole model-fit results from the database.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/ellipse/fit.py
+++ b/scripts/ellipse/fit.py
@@ -27,16 +27,16 @@ These are documented fully in the `autogalaxy_workspace/*/guides/data_structures
 
 __Contents__
 
-**Loading Data:** Loading the imaging dataset from FITS files for ellipse fitting.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Mask:** Applying a circular mask to the dataset.
-**Ellipse Interpolation:** Interpolating data and noise-map values onto ellipse coordinates.
-**Ellipse Fitting:** Computing model data, residuals and chi-squared for an ellipse fit.
-**FitEllipse:** Using the FitEllipse object to perform and inspect the ellipse fit.
-**Multiple Ellipses:** Fitting multiple ellipses of increasing size to trace the galaxy.
-**Bad Fit:** Demonstrating how a poor ellipse model produces residuals.
-**Fit Quantities:** Inspecting model data, residual maps and chi-squared maps.
-**Figures of Merit:** Computing chi-squared and log likelihood values.
+- **Loading Data:** Loading the imaging dataset from FITS files for ellipse fitting.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Mask:** Applying a circular mask to the dataset.
+- **Ellipse Interpolation:** Interpolating data and noise-map values onto ellipse coordinates.
+- **Ellipse Fitting:** Computing model data, residuals and chi-squared for an ellipse fit.
+- **FitEllipse:** Using the FitEllipse object to perform and inspect the ellipse fit.
+- **Multiple Ellipses:** Fitting multiple ellipses of increasing size to trace the galaxy.
+- **Bad Fit:** Demonstrating how a poor ellipse model produces residuals.
+- **Fit Quantities:** Inspecting model data, residual maps and chi-squared maps.
+- **Figures of Merit:** Computing chi-squared and log likelihood values.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/ellipse/modeling.py
+++ b/scripts/ellipse/modeling.py
@@ -35,21 +35,21 @@ These are documented fully in the `autogalaxy_workspace/*/guides/data_structures
 
 __Contents__
 
-**Loading Data:** Loading the imaging dataset from FITS files for ellipse fitting.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Mask:** Applying a circular mask to the dataset.
-**Model Composition:** Composing an ellipse model with free centre and elliptical components.
-**Search:** Configuring the Dynesty non-linear search for ellipse fitting.
-**Analysis:** Setting up the AnalysisEllipse object for the model fit.
-**Run Times:** Estimating the computational cost of the ellipse model fit.
-**Model-Fit:** Running the non-linear search to fit the ellipse to data.
-**Output Folder Layout:** Description of the structure of the `output` folder where results are written.
-**Result:** Inspecting the result object and maximum likelihood ellipse parameters.
-**Multiple Ellipses:** Fitting many ellipses of increasing size to trace the full galaxy.
-**Final Fit:** Combining all ellipses into a single final fit.
-**Masking:** Applying an extra galaxies mask and repeating the ellipse fitting.
-**Data Preparation:** Pointers to data preparation scripts for your own data.
-**HowToGalaxy:** Pointers to the HowToGalaxy lecture series for light profile modeling.
+- **Loading Data:** Loading the imaging dataset from FITS files for ellipse fitting.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Mask:** Applying a circular mask to the dataset.
+- **Model Composition:** Composing an ellipse model with free centre and elliptical components.
+- **Search:** Configuring the Dynesty non-linear search for ellipse fitting.
+- **Analysis:** Setting up the AnalysisEllipse object for the model fit.
+- **Run Times:** Estimating the computational cost of the ellipse model fit.
+- **Model-Fit:** Running the non-linear search to fit the ellipse to data.
+- **Output Folder Layout:** Description of the structure of the `output` folder where results are written.
+- **Result:** Inspecting the result object and maximum likelihood ellipse parameters.
+- **Multiple Ellipses:** Fitting many ellipses of increasing size to trace the full galaxy.
+- **Final Fit:** Combining all ellipses into a single final fit.
+- **Masking:** Applying an extra galaxies mask and repeating the ellipse fitting.
+- **Data Preparation:** Pointers to data preparation scripts for your own data.
+- **HowToGalaxy:** Pointers to the HowToGalaxy lecture series for light profile modeling.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/ellipse/multipoles.py
+++ b/scripts/ellipse/multipoles.py
@@ -16,21 +16,21 @@ composed. It only discusses new aspects of the API that are used to perform mult
 
 __Contents__
 
-**Loading Data:** Loading the imaging dataset from FITS files.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Mask:** Applying a circular mask to the dataset.
-**Multipole Fit:** Fitting an ellipse with a fourth-order multipole perturbation.
-**Multipole Order:** Combining multipoles of different orders for complex shapes.
-**Multiple Perturbed Ellipses:** Fitting many ellipses with multipoles to trace the full galaxy.
-**Modeling:** Performing model-fitting via a non-linear search with multipole components.
-**Search:** Configuring the Dynesty non-linear search for multipole fitting.
-**Analysis:** Setting up the AnalysisEllipse object for the model fit.
-**Run Times:** Estimating the computational cost of multipole model fits.
-**Model-Fit:** Running the non-linear search to fit ellipses with multipoles.
-**Result:** Inspecting the result and inferred multipole parameters.
-**Multiple Ellipses:** Fitting many ellipses with multipoles across the full galaxy.
-**Final Fit:** Combining all ellipses and multipoles into a single final fit.
-**Masking:** Applying an extra galaxies mask and repeating the multipole fitting.
+- **Loading Data:** Loading the imaging dataset from FITS files.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Mask:** Applying a circular mask to the dataset.
+- **Multipole Fit:** Fitting an ellipse with a fourth-order multipole perturbation.
+- **Multipole Order:** Combining multipoles of different orders for complex shapes.
+- **Multiple Perturbed Ellipses:** Fitting many ellipses with multipoles to trace the full galaxy.
+- **Modeling:** Performing model-fitting via a non-linear search with multipole components.
+- **Search:** Configuring the Dynesty non-linear search for multipole fitting.
+- **Analysis:** Setting up the AnalysisEllipse object for the model fit.
+- **Run Times:** Estimating the computational cost of multipole model fits.
+- **Model-Fit:** Running the non-linear search to fit ellipses with multipoles.
+- **Result:** Inspecting the result and inferred multipole parameters.
+- **Multiple Ellipses:** Fitting many ellipses with multipoles across the full galaxy.
+- **Final Fit:** Combining all ellipses and multipoles into a single final fit.
+- **Masking:** Applying an extra galaxies mask and repeating the multipole fitting.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/ellipse/simulator.py
+++ b/scripts/ellipse/simulator.py
@@ -15,12 +15,12 @@ This script simulates `Imaging` of a galaxy using light profiles where:
 
 __Contents__
 
-**Dataset Paths:** Setting the output path for simulated data.
-**Grid:** Creating the 2D grid for evaluating galaxy images with adaptive over-sampling.
-**Galaxies:** Setting up the galaxy with an elliptical Sersic bulge.
-**Output:** Saving the simulated dataset to FITS files.
-**Visualize:** Outputting subplot and image visualizations as PNG files.
-**Plane Output:** Saving the galaxy model as a JSON file for future reference.
+- **Dataset Paths:** Setting the output path for simulated data.
+- **Grid:** Creating the 2D grid for evaluating galaxy images with adaptive over-sampling.
+- **Galaxies:** Setting up the galaxy with an elliptical Sersic bulge.
+- **Output:** Saving the simulated dataset to FITS files.
+- **Visualize:** Outputting subplot and image visualizations as PNG files.
+- **Plane Output:** Saving the galaxy model as a JSON file for future reference.
 
 __Start Here Notebook__
 

--- a/scripts/guides/advanced/over_sampling.py
+++ b/scripts/guides/advanced/over_sampling.py
@@ -19,14 +19,14 @@ will give an accurate estimate of the total intensity within the pixel.
 
 __Contents__
 
-**Illustration:** Visualize how over-sampling splits pixels into sub-grids of coordinates.
-**Numerics:** Inspect the numerical values of sub-pixel coordinates in the over-sampled grid.
-**Images:** Compute Sersic profile images with different over-sampling levels and compare residuals.
-**Adaptive Over Sampling:** Use radial bins to apply high over-sampling only where needed.
-**Default Over-Sampling:** The default over-sampling scheme used by PyAutoGalaxy.
-**Multiple Galaxies:** Apply adaptive over-sampling with multiple galaxy centres.
-**Dataset & Modeling:** Apply over-sampling to imaging datasets for model fitting.
-**Pixelization:** Apply over-sampling to pixelized source reconstructions.
+- **Illustration:** Visualize how over-sampling splits pixels into sub-grids of coordinates.
+- **Numerics:** Inspect the numerical values of sub-pixel coordinates in the over-sampled grid.
+- **Images:** Compute Sersic profile images with different over-sampling levels and compare residuals.
+- **Adaptive Over Sampling:** Use radial bins to apply high over-sampling only where needed.
+- **Default Over-Sampling:** The default over-sampling scheme used by PyAutoGalaxy.
+- **Multiple Galaxies:** Apply adaptive over-sampling with multiple galaxy centres.
+- **Dataset & Modeling:** Apply over-sampling to imaging datasets for model fitting.
+- **Pixelization:** Apply over-sampling to pixelized source reconstructions.
 
 __Default Over-Sampling__
 

--- a/scripts/guides/data_structures.py
+++ b/scripts/guides/data_structures.py
@@ -14,17 +14,17 @@ These data structures use the `slim` and `native` data representations API to ma
 
 __Contents__
 
-**Units:** The internal unit system used throughout this example.
-**API:** Create the three main data structures (Array2D, Grid2D, VectorYX2D) without a mask.
-**Grids:** Create and plot a uniform Grid2D of (y,x) coordinates.
-**Native:** Access the grid in its native 2D representation.
-**Slim:** Access the grid in its slimmed-down 1D representation.
-**Masked Data Structures:** How masking changes the slim and native representations.
-**Data:** Using Array2D objects to store 2D data like images and noise maps.
-**Dataset Auto-Simulation:** Auto-simulate the dataset if it does not exist.
-**Galaxies:** Computing galaxy images and inspecting their data structures.
-**Irregular Structures:** Evaluating light profiles on irregular grids of coordinates.
-**Vector Quantities:** Working with vector (y,x) quantities like deflection angles using VectorYX2D.
+- **Units:** The internal unit system used throughout this example.
+- **API:** Create the three main data structures (Array2D, Grid2D, VectorYX2D) without a mask.
+- **Grids:** Create and plot a uniform Grid2D of (y,x) coordinates.
+- **Native:** Access the grid in its native 2D representation.
+- **Slim:** Access the grid in its slimmed-down 1D representation.
+- **Masked Data Structures:** How masking changes the slim and native representations.
+- **Data:** Using Array2D objects to store 2D data like images and noise maps.
+- **Dataset Auto-Simulation:** Auto-simulate the dataset if it does not exist.
+- **Galaxies:** Computing galaxy images and inspecting their data structures.
+- **Irregular Structures:** Evaluating light profiles on irregular grids of coordinates.
+- **Vector Quantities:** Working with vector (y,x) quantities like deflection angles using VectorYX2D.
 
 __Units__
 

--- a/scripts/guides/galaxies.py
+++ b/scripts/guides/galaxies.py
@@ -6,21 +6,21 @@ This tutorial shows how to use galaxies, including visualizing and extracting th
 
 __Contents__
 
-**Units:** The internal unit system used throughout this example.
-**Data Structures:** Overview of bespoke data structures and the slim/native API.
-**Grids:** Create a 2D grid of (y,x) coordinates for evaluating galaxy light.
-**Light Profiles:** Define Sersic and other light profiles to describe a galaxy's luminosity distribution.
-**Galaxies:** Create Galaxy objects from multiple light profiles and compute their images.
-**Galaxies (multiple):** Group multiple galaxies into a Galaxies object and compute combined images.
-**Log10:** Plot galaxy images in log10 space for clearer visualization of outskirts.
-**Extending Objects:** Create complex multi-galaxy systems with many light profiles.
-**Data Structures Slim / Native:** Access images in 1D slim or 2D native representations.
-**Individual Galaxy Components:** Extract and plot individual light profile components from galaxies.
-**Galaxies Composition:** Summarize the composition of galaxies and their profiles.
-**One Dimension Projection:** Create projected 2D radial grids for 1D profile calculations.
-**One Dimensional Quantities:** Compute and plot 1D radial profiles of galaxy light.
-**Decomposed 1D Plot:** Plot decomposed 1D profiles showing each light component separately.
-**Modeling Results:** Pointers to results-specific functionality for galaxy models.
+- **Units:** The internal unit system used throughout this example.
+- **Data Structures:** Overview of bespoke data structures and the slim/native API.
+- **Grids:** Create a 2D grid of (y,x) coordinates for evaluating galaxy light.
+- **Light Profiles:** Define Sersic and other light profiles to describe a galaxy's luminosity distribution.
+- **Galaxies:** Create Galaxy objects from multiple light profiles and compute their images.
+- **Galaxies (multiple):** Group multiple galaxies into a Galaxies object and compute combined images.
+- **Log10:** Plot galaxy images in log10 space for clearer visualization of outskirts.
+- **Extending Objects:** Create complex multi-galaxy systems with many light profiles.
+- **Data Structures Slim / Native:** Access images in 1D slim or 2D native representations.
+- **Individual Galaxy Components:** Extract and plot individual light profile components from galaxies.
+- **Galaxies Composition:** Summarize the composition of galaxies and their profiles.
+- **One Dimension Projection:** Create projected 2D radial grids for 1D profile calculations.
+- **One Dimensional Quantities:** Compute and plot 1D radial profiles of galaxy light.
+- **Decomposed 1D Plot:** Plot decomposed 1D profiles showing each light component separately.
+- **Modeling Results:** Pointers to results-specific functionality for galaxy models.
 
 __Units__
 

--- a/scripts/guides/hpc/example_cpu_and_gpu.py
+++ b/scripts/guides/hpc/example_cpu_and_gpu.py
@@ -36,15 +36,15 @@ using the sync script.
 """
 __Contents__
 
-**HPC Output Path:** Set the output path for results on the HPC.
-**HPC Dataset Path:** Set the path where datasets are stored on the HPC.
-**HPC Home Path:** Set the home directory path and config path on the HPC.
-**Batch Script: Many Datasets (Array Job):** Configure a SLURM array job to fit many datasets in parallel.
-**Batch Script: Single Dataset with Multiple CPUs:** Configure a parallelized single-dataset Nautilus fit.
-**Dataset:** Load the dataset for the HPC model-fit.
-**Nautilus CPUs:** Configure Nautilus to use multiple CPU cores for parallelized sampling.
-**Galaxy Modeling:** Perform a standard galaxy model-fit on the HPC.
-**GPU Jobs:** Run GPU-accelerated model-fits using the GPU batch script.
+- **HPC Output Path:** Set the output path for results on the HPC.
+- **HPC Dataset Path:** Set the path where datasets are stored on the HPC.
+- **HPC Home Path:** Set the home directory path and config path on the HPC.
+- **Batch Script: Many Datasets (Array Job):** Configure a SLURM array job to fit many datasets in parallel.
+- **Batch Script: Single Dataset with Multiple CPUs:** Configure a parallelized single-dataset Nautilus fit.
+- **Dataset:** Load the dataset for the HPC model-fit.
+- **Nautilus CPUs:** Configure Nautilus to use multiple CPU cores for parallelized sampling.
+- **Galaxy Modeling:** Perform a standard galaxy model-fit on the HPC.
+- **GPU Jobs:** Run GPU-accelerated model-fits using the GPU batch script.
 
 __HPC Output Path__
 

--- a/scripts/guides/modeling/bug_fix.py
+++ b/scripts/guides/modeling/bug_fix.py
@@ -13,8 +13,8 @@ Comments have therefore been removed to avoid repetition and make the script mor
 
 __Contents__
 
-**The Fix:** The code pattern that fixes parallelization issues on certain operating systems.
-**Trouble Shooting:** What to do if parallelization still does not work after applying the fix.
+- **The Fix:** The code pattern that fixes parallelization issues on certain operating systems.
+- **Trouble Shooting:** What to do if parallelization still does not work after applying the fix.
 
 __The Fix__
 

--- a/scripts/guides/modeling/chaining.py
+++ b/scripts/guides/modeling/chaining.py
@@ -21,16 +21,16 @@ The benefits of non-linear search chaining are:
 
 __Contents__
 
-**Dataset + Masking:** Load, plot and mask the imaging data.
-**Paths:** Set the output path for chained search results.
-**Model (Search 1):** Compose the model for the first search in the chain.
-**Search + Analysis + Model-Fit (Search 1):** Run the first non-linear search.
-**Result (Search 1):** Inspect the results of the first search.
-**Model Chaining:** Pass results from search 1 to initialize the model of search 2.
-**Search + Analysis + Model-Fit (Search 2):** Run the second non-linear search with refined priors.
-**Result (Search 2):** Inspect the final results of the chained search.
-**Detailed Explanation Of Prior Passing:** In-depth explanation of how priors are passed between searches.
-**EXAMPLE:** A worked example of prior passing for a Sersic sersic_index parameter.
+- **Dataset + Masking:** Load, plot and mask the imaging data.
+- **Paths:** Set the output path for chained search results.
+- **Model (Search 1):** Compose the model for the first search in the chain.
+- **Search + Analysis + Model-Fit (Search 1):** Run the first non-linear search.
+- **Result (Search 1):** Inspect the results of the first search.
+- **Model Chaining:** Pass results from search 1 to initialize the model of search 2.
+- **Search + Analysis + Model-Fit (Search 2):** Run the second non-linear search with refined priors.
+- **Result (Search 2):** Inspect the final results of the chained search.
+- **Detailed Explanation Of Prior Passing:** In-depth explanation of how priors are passed between searches.
+- **EXAMPLE:** A worked example of prior passing for a Sersic sersic_index parameter.
 
 __This Example__
 

--- a/scripts/guides/modeling/cookbook.py
+++ b/scripts/guides/modeling/cookbook.py
@@ -10,19 +10,19 @@ readable code for different use-cases.
 
 __Contents__
 
-**Simple Model:** Compose a model with a galaxy having a single Sersic light profile.
-**More Complex Models:** Compose models with multiple light profiles and multiple galaxies.
-**Concise API:** A shorthand API for composing models more concisely.
-**Prior Customization:** Customize the priors of individual model parameters.
-**Model Customization:** Pair, fix and offset model parameters to reduce complexity.
-**Available Model Components:** Links to API documentation for all available light and mass profiles.
-**JSon Outputs:** Save and load models as JSON files.
-**Many Profile Models (Advanced):** Compose models with many profiles using MGE or shapelets.
-**Model Linking (Advanced):** Link inferred models between searches in a chain.
-**Across Datasets (Advanced):** Compose models that share components across multiple datasets.
-**Relations (Advanced):** Compose models where parameters vary according to a user-specified function.
-**PyAutoFit API:** Links to the PyAutoFit model composition cookbooks for more advanced usage.
-**Wrap Up:** Summary of model composition tools.
+- **Simple Model:** Compose a model with a galaxy having a single Sersic light profile.
+- **More Complex Models:** Compose models with multiple light profiles and multiple galaxies.
+- **Concise API:** A shorthand API for composing models more concisely.
+- **Prior Customization:** Customize the priors of individual model parameters.
+- **Model Customization:** Pair, fix and offset model parameters to reduce complexity.
+- **Available Model Components:** Links to API documentation for all available light and mass profiles.
+- **JSon Outputs:** Save and load models as JSON files.
+- **Many Profile Models (Advanced):** Compose models with many profiles using MGE or shapelets.
+- **Model Linking (Advanced):** Link inferred models between searches in a chain.
+- **Across Datasets (Advanced):** Compose models that share components across multiple datasets.
+- **Relations (Advanced):** Compose models where parameters vary according to a user-specified function.
+- **PyAutoFit API:** Links to the PyAutoFit model composition cookbooks for more advanced usage.
+- **Wrap Up:** Summary of model composition tools.
 
 __Start Here Notebook__
 

--- a/scripts/guides/modeling/customize.py
+++ b/scripts/guides/modeling/customize.py
@@ -7,9 +7,9 @@ reasons explaining why each customization is useful.
 
 __Contents__
 
-**Dataset**: Load a dataset which is used to illustrate the customizations.
-**Mask:** Apply a custom mask to the dataset, which can be used to remove regions of the image that contain no emission.
-**Over Sampling:** Change the over sampling used to compute the surface brightness of every image-pixel.
+- **Dataset**: Load a dataset which is used to illustrate the customizations.
+- **Mask:** Apply a custom mask to the dataset, which can be used to remove regions of the image that contain no emission.
+- **Over Sampling:** Change the over sampling used to compute the surface brightness of every image-pixel.
 
 __Start Here Notebook__
 

--- a/scripts/guides/modeling/searches.py
+++ b/scripts/guides/modeling/searches.py
@@ -23,12 +23,12 @@ object and pass these to the search to perform the fit. We skip these steps for 
 
 __Contents__
 
-**Dynesty**: A nested sampling algorithm that is effective for modeling, with a lot of customization.
-**Emcee**: An ensemble MCMC sampler that is commonly used in Astronomy and Astrophysics.
-**Zeus**: An ensemble MCMC slice sampler that is the most effective MCMC method for modeling.
-**LBFGS**: A quasi-Newton optimization algorithm that is a maximum likelihood estimator (MLE) method.
-**Start Point**: An API that allows the user to specify the start-point of a model-fit, which is useful for MCMC and MLE methods.
-**Search Cookbook**: A cookbook that documents all searches available in **PyAutoFit**, including those not documented here.
+- **Dynesty**: A nested sampling algorithm that is effective for modeling, with a lot of customization.
+- **Emcee**: An ensemble MCMC sampler that is commonly used in Astronomy and Astrophysics.
+- **Zeus**: An ensemble MCMC slice sampler that is the most effective MCMC method for modeling.
+- **LBFGS**: A quasi-Newton optimization algorithm that is a maximum likelihood estimator (MLE) method.
+- **Start Point**: An API that allows the user to specify the start-point of a model-fit, which is useful for MCMC and MLE methods.
+- **Search Cookbook**: A cookbook that documents all searches available in **PyAutoFit**, including those not documented here.
 
 __Start Here Notebook__
 

--- a/scripts/guides/plot/advanced/plotters_pixelization.py
+++ b/scripts/guides/plot/advanced/plotters_pixelization.py
@@ -12,13 +12,13 @@ behaviour of plotting visuals.
 
 __Contents__
 
-**Setup:** Set up all objects (e.g. grid, dataset, fit) used to illustrate plotting.
-**Fit Imaging:** Plot the fit of a model to an imaging dataset that uses a pixelization.
-**Reconstruction:** Plot the reconstructed source galaxy mapped back to the image frame.
-**Inversion Plots:** Plot diagnostic subplots of the inversion properties using subplot_of_mapper.
-**Mapper:** Plot the mapper that maps image-plane pixels to the source-plane pixelization.
-**Mesh Grids:** Plot the image and source plane mesh grids.
-**Delaunay:** Customize the filling of Delaunay mesh plots.
+- **Setup:** Set up all objects (e.g. grid, dataset, fit) used to illustrate plotting.
+- **Fit Imaging:** Plot the fit of a model to an imaging dataset that uses a pixelization.
+- **Reconstruction:** Plot the reconstructed source galaxy mapped back to the image frame.
+- **Inversion Plots:** Plot diagnostic subplots of the inversion properties using subplot_of_mapper.
+- **Mapper:** Plot the mapper that maps image-plane pixels to the source-plane pixelization.
+- **Mesh Grids:** Plot the image and source plane mesh grids.
+- **Delaunay:** Customize the filling of Delaunay mesh plots.
 
 __Setup__
 

--- a/scripts/guides/plot/examples/plotters.py
+++ b/scripts/guides/plot/examples/plotters.py
@@ -15,18 +15,18 @@ behaviour of plotting visuals.
 
 __Contents__
 
-**Setup:** Set up all objects (e.g. grid, dataset, fit) used to illustrate plotting.
-**Array2D:** Plot a 2D array using `aplt.plot_array`.
-**Grid2D:** Plot a 2D grid of coordinates using `aplt.plot_grid`.
-**Light Profile:** Plot a light profile image using `aplt.plot_array`.
-**Galaxy:** Plot a galaxy's image using `aplt.plot_array`.
-**Galaxies:** Plot galaxies using `aplt.plot_array` and `aplt.subplot_galaxies`.
-**Imaging:** Plot an imaging dataset using `aplt.subplot_imaging_dataset`.
-**Fit Imaging:** Plot a fit to imaging data using `aplt.subplot_fit_imaging`.
-**Log10:** Plot galaxy images in log10 space for clearer visualization.
-**One Dimensional Plots:** Plot 1D radial profiles using standard matplotlib.
-**Output:** Save figures to disk using `output_path`, `output_filename`, `output_format` arguments.
-**Probability Density Function (PDF) Plots:** Plot 1D light profiles with error regions from model-fit PDFs.
+- **Setup:** Set up all objects (e.g. grid, dataset, fit) used to illustrate plotting.
+- **Array2D:** Plot a 2D array using `aplt.plot_array`.
+- **Grid2D:** Plot a 2D grid of coordinates using `aplt.plot_grid`.
+- **Light Profile:** Plot a light profile image using `aplt.plot_array`.
+- **Galaxy:** Plot a galaxy's image using `aplt.plot_array`.
+- **Galaxies:** Plot galaxies using `aplt.plot_array` and `aplt.subplot_galaxies`.
+- **Imaging:** Plot an imaging dataset using `aplt.subplot_imaging_dataset`.
+- **Fit Imaging:** Plot a fit to imaging data using `aplt.subplot_fit_imaging`.
+- **Log10:** Plot galaxy images in log10 space for clearer visualization.
+- **One Dimensional Plots:** Plot 1D radial profiles using standard matplotlib.
+- **Output:** Save figures to disk using `output_path`, `output_filename`, `output_format` arguments.
+- **Probability Density Function (PDF) Plots:** Plot 1D light profiles with error regions from model-fit PDFs.
 
 __Setup__
 

--- a/scripts/guides/plot/examples/visuals.py
+++ b/scripts/guides/plot/examples/visuals.py
@@ -13,15 +13,15 @@ behaviour of plotting visuals.
 
 __Contents__
 
-**Setup:** Set up objects (grid, galaxies, dataset) used to illustrate visual overlays.
-**Light Profile Centres:** Overlay light profile centres on an image using positions.
-**Mask:** Overlay a mask on an image.
-**Origin:** Overlay the coordinate origin on an image.
-**Grid:** Overlay a grid of (y,x) coordinates on an image.
-**Border:** Overlay the border of a mask on an image.
-**Array Overlay:** Overlay a 2D array on an image.
-**Patch Overlay:** Overlay matplotlib patches (e.g. ellipses) on an image.
-**Vector Field:** Overlay a quiver plot of vectors on an image.
+- **Setup:** Set up objects (grid, galaxies, dataset) used to illustrate visual overlays.
+- **Light Profile Centres:** Overlay light profile centres on an image using positions.
+- **Mask:** Overlay a mask on an image.
+- **Origin:** Overlay the coordinate origin on an image.
+- **Grid:** Overlay a grid of (y,x) coordinates on an image.
+- **Border:** Overlay the border of a mask on an image.
+- **Array Overlay:** Overlay a 2D array on an image.
+- **Patch Overlay:** Overlay matplotlib patches (e.g. ellipses) on an image.
+- **Vector Field:** Overlay a quiver plot of vectors on an image.
 
 __Setup__
 

--- a/scripts/guides/plot/simulator.py
+++ b/scripts/guides/plot/simulator.py
@@ -11,12 +11,12 @@ This dataset is used in chapter 3 of the **HowToGalaxy** lectures.
 
 __Contents__
 
-**Dataset Paths:** Set the output path for the simulated dataset.
-**Grid:** Create a 2D grid with adaptive over-sampling for simulation.
-**Galaxies:** Define the galaxy light profiles used for simulation.
-**Output:** Save the simulated dataset to FITS files.
-**Visualize:** Output subplot and image PNGs of the simulated dataset.
-**Plane Output:** Save the Galaxies object as a JSON file.
+- **Dataset Paths:** Set the output path for the simulated dataset.
+- **Grid:** Create a 2D grid with adaptive over-sampling for simulation.
+- **Galaxies:** Define the galaxy light profiles used for simulation.
+- **Output:** Save the simulated dataset to FITS files.
+- **Visualize:** Output subplot and image PNGs of the simulated dataset.
+- **Plane Output:** Save the Galaxies object as a JSON file.
 
 __Advanced__
 

--- a/scripts/guides/results/aggregator/data_fitting.py
+++ b/scripts/guides/results/aggregator/data_fitting.py
@@ -10,11 +10,11 @@ like its visualization and also inspect fits randomly drawm from the PDF.
 
 __Contents__
 
-**Aggregator:** Load results using the Aggregator.
-**Fits via Aggregator:** Load datasets and maximum log likelihood fits using ImagingAgg and FitImagingAgg.
-**Modification:** Modify fit settings (e.g. over-sampling) when loading fits from the aggregator.
-**Visualization Customization:** Customize plot appearance when inspecting fits via the aggregator.
-**Errors (Random draws from PDF):** Inspect how fits vary within the PDF errors.
+- **Aggregator:** Load results using the Aggregator.
+- **Fits via Aggregator:** Load datasets and maximum log likelihood fits using ImagingAgg and FitImagingAgg.
+- **Modification:** Modify fit settings (e.g. over-sampling) when loading fits from the aggregator.
+- **Visualization Customization:** Customize plot appearance when inspecting fits via the aggregator.
+- **Errors (Random draws from PDF):** Inspect how fits vary within the PDF errors.
 
 __Interferometer__
 

--- a/scripts/guides/results/aggregator/galaxies_fit.py
+++ b/scripts/guides/results/aggregator/galaxies_fit.py
@@ -15,10 +15,10 @@ and therefore you should read these guides in detail first.
 
 __Contents__
 
-**Model Fit:** Perform a model-fit to create a Result object for inspecting galaxies and fits.
-**Max Likelihood Galaxies:** Visualize the maximum likelihood galaxies from the result.
-**Samples:** Extract individual galaxy components from the samples and plot their images.
-**Refitting:** Refit the data using different samples to inspect how the fit varies.
+- **Model Fit:** Perform a model-fit to create a Result object for inspecting galaxies and fits.
+- **Max Likelihood Galaxies:** Visualize the maximum likelihood galaxies from the result.
+- **Samples:** Extract individual galaxy components from the samples and plot their images.
+- **Refitting:** Refit the data using different samples to inspect how the fit varies.
 
 __Units__
 

--- a/scripts/guides/results/aggregator/models.py
+++ b/scripts/guides/results/aggregator/models.py
@@ -11,11 +11,11 @@ can be loaded.
 
 __Contents__
 
-**Aggregator:** Load results using the Aggregator.
-**Galaxies via Aggregator:** Load maximum log likelihood Galaxies objects using GalaxiesAgg.
-**Luminosity Example:** Compute the luminosity of each galaxy from aggregated results.
-**Errors (PDF from samples):** Compute errors on derived quantities like axis ratio from the full PDF.
-**Errors (Random draws from PDF):** Estimate errors using random draws from the PDF.
+- **Aggregator:** Load results using the Aggregator.
+- **Galaxies via Aggregator:** Load maximum log likelihood Galaxies objects using GalaxiesAgg.
+- **Luminosity Example:** Compute the luminosity of each galaxy from aggregated results.
+- **Errors (PDF from samples):** Compute errors on derived quantities like axis ratio from the full PDF.
+- **Errors (Random draws from PDF):** Estimate errors using random draws from the PDF.
 
 __Database File__
 

--- a/scripts/guides/results/aggregator/queries.py
+++ b/scripts/guides/results/aggregator/queries.py
@@ -11,11 +11,11 @@ can be loaded.
 
 __Contents__
 
-**Loading From Hard-disk:** Load results using the Aggregator from the output directory.
-**Unique Tag:** Query results by the unique_tag string used in the search.
-**Search Name:** Query results by the name of the non-linear search.
-**Model Queries:** Query results based on the model components fitted.
-**Logic:** Combine queries using AND (&) and OR (|) logical operators.
+- **Loading From Hard-disk:** Load results using the Aggregator from the output directory.
+- **Unique Tag:** Query results by the unique_tag string used in the search.
+- **Search Name:** Query results by the name of the non-linear search.
+- **Model Queries:** Query results based on the model components fitted.
+- **Logic:** Combine queries using AND (&) and OR (|) logical operators.
 
 __Database File__
 

--- a/scripts/guides/results/aggregator/samples.py
+++ b/scripts/guides/results/aggregator/samples.py
@@ -10,23 +10,23 @@ This script illustrates how to use the result to inspect the non-linear search s
 
 __Contents__
 
-**Model Fit:** Perform a model-fit to create a Result object containing samples.
-**Info:** Print the result in a readable format.
-**Plot:** Plot the maximum likelihood galaxies and fit.
-**Samples:** Access the Samples object containing all non-linear search samples.
-**Parameters:** Inspect the parameter lists of each sample.
-**Figures of Merit:** Access log likelihood, log prior, log posterior and weights of samples.
-**Instances:** Create model instances from samples (e.g. maximum log likelihood).
-**Posterior / PDF:** Estimate parameters via 1D marginalization of their PDFs.
-**Errors:** Compute error estimates at a given sigma confidence limit.
-**Sample Instance:** Create an instance from any specific sample.
-**Search Plots:** Plot PDFs using the non-linear search visualization tools.
-**Maximum Likelihood:** Extract the maximum log likelihood value for model comparison.
-**Bayesian Evidence:** Access the Bayesian evidence for model comparison via Occam's Razor.
-**Lists:** Return results as 1D lists instead of model instances.
-**Latex:** Generate LaTeX table code for parameter estimates.
-**Derived Errors (Advanced):** Compute errors on derived quantities not directly sampled.
-**Samples Filtering (Advanced):** Filter samples to inspect specific parameters.
+- **Model Fit:** Perform a model-fit to create a Result object containing samples.
+- **Info:** Print the result in a readable format.
+- **Plot:** Plot the maximum likelihood galaxies and fit.
+- **Samples:** Access the Samples object containing all non-linear search samples.
+- **Parameters:** Inspect the parameter lists of each sample.
+- **Figures of Merit:** Access log likelihood, log prior, log posterior and weights of samples.
+- **Instances:** Create model instances from samples (e.g. maximum log likelihood).
+- **Posterior / PDF:** Estimate parameters via 1D marginalization of their PDFs.
+- **Errors:** Compute error estimates at a given sigma confidence limit.
+- **Sample Instance:** Create an instance from any specific sample.
+- **Search Plots:** Plot PDFs using the non-linear search visualization tools.
+- **Maximum Likelihood:** Extract the maximum log likelihood value for model comparison.
+- **Bayesian Evidence:** Access the Bayesian evidence for model comparison via Occam's Razor.
+- **Lists:** Return results as 1D lists instead of model instances.
+- **Latex:** Generate LaTeX table code for parameter estimates.
+- **Derived Errors (Advanced):** Compute errors on derived quantities not directly sampled.
+- **Samples Filtering (Advanced):** Filter samples to inspect specific parameters.
 
 __Units__
 

--- a/scripts/guides/results/aggregator/samples_via_aggregator.py
+++ b/scripts/guides/results/aggregator/samples_via_aggregator.py
@@ -16,24 +16,24 @@ can copy and paste the code to use in your own scripts!
 
 __Contents__
 
-**Files:** The output files that are loaded when accessing samples via the database.
-**Generators:** How Python generators are used for memory-efficient result loading.
-**Samples:** Access the Samples object from the aggregator.
-**Parameters:** Inspect the parameter lists of each sample.
-**Samples Info:** Access additional metadata about the samples (e.g. live points, steps).
-**Samples Summary:** Access a precomputed summary of key results for fast retrieval.
-**Figures of Merit:** Access log likelihood, log prior, log posterior and weights.
-**Instances:** Create model instances (e.g. maximum log likelihood) from aggregated samples.
-**Posterior / PDF:** Estimate parameters via 1D marginalization of their PDFs.
-**Errors:** Compute error estimates at a given sigma confidence limit.
-**Sample Instance:** Create an instance from any specific sample.
-**Search Plots:** Plot PDFs using the non-linear search visualization tools.
-**Maximum Likelihood:** Extract the maximum log likelihood value for model comparison.
-**Bayesian Evidence:** Access the Bayesian evidence for model comparison.
-**Lists:** Return results as 1D lists instead of model instances.
-**Latex:** Generate LaTeX table code for parameter estimates.
-**Ordering:** Control the ordering of aggregated results.
-**Samples Filtering:** Filter samples to inspect specific parameters.
+- **Files:** The output files that are loaded when accessing samples via the database.
+- **Generators:** How Python generators are used for memory-efficient result loading.
+- **Samples:** Access the Samples object from the aggregator.
+- **Parameters:** Inspect the parameter lists of each sample.
+- **Samples Info:** Access additional metadata about the samples (e.g. live points, steps).
+- **Samples Summary:** Access a precomputed summary of key results for fast retrieval.
+- **Figures of Merit:** Access log likelihood, log prior, log posterior and weights.
+- **Instances:** Create model instances (e.g. maximum log likelihood) from aggregated samples.
+- **Posterior / PDF:** Estimate parameters via 1D marginalization of their PDFs.
+- **Errors:** Compute error estimates at a given sigma confidence limit.
+- **Sample Instance:** Create an instance from any specific sample.
+- **Search Plots:** Plot PDFs using the non-linear search visualization tools.
+- **Maximum Likelihood:** Extract the maximum log likelihood value for model comparison.
+- **Bayesian Evidence:** Access the Bayesian evidence for model comparison.
+- **Lists:** Return results as 1D lists instead of model instances.
+- **Latex:** Generate LaTeX table code for parameter estimates.
+- **Ordering:** Control the ordering of aggregated results.
+- **Samples Filtering:** Filter samples to inspect specific parameters.
 
 __Samples via Result__
 

--- a/scripts/guides/results/database/simulators/light_sersic_exp__0.py
+++ b/scripts/guides/results/database/simulators/light_sersic_exp__0.py
@@ -9,14 +9,14 @@ This script simulates `Imaging` of a galaxy using light profiles where:
 
 __Contents__
 
-**Dataset Paths:** Set the output path for the simulated dataset.
-**Grid:** Create a 2D grid for simulation.
-**Over Sampling:** Apply adaptive over-sampling for accurate image evaluation.
-**Galaxies:** Define the galaxy light profiles used for simulation.
-**Output:** Save the simulated dataset to FITS files.
-**Visualize:** Output subplot and image PNGs of the simulated dataset.
-**Plane Output:** Save the Galaxies object as a JSON file.
-**Info:** Save metadata (redshift, velocity dispersion) as a JSON file.
+- **Dataset Paths:** Set the output path for the simulated dataset.
+- **Grid:** Create a 2D grid for simulation.
+- **Over Sampling:** Apply adaptive over-sampling for accurate image evaluation.
+- **Galaxies:** Define the galaxy light profiles used for simulation.
+- **Output:** Save the simulated dataset to FITS files.
+- **Visualize:** Output subplot and image PNGs of the simulated dataset.
+- **Plane Output:** Save the Galaxies object as a JSON file.
+- **Info:** Save metadata (redshift, velocity dispersion) as a JSON file.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/guides/results/database/simulators/light_sersic_exp__1.py
+++ b/scripts/guides/results/database/simulators/light_sersic_exp__1.py
@@ -9,14 +9,14 @@ This script simulates `Imaging` of a galaxy using light profiles where:
 
 __Contents__
 
-**Dataset Paths:** Set the output path for the simulated dataset.
-**Grid:** Create a 2D grid for simulation.
-**Over Sampling:** Apply adaptive over-sampling for accurate image evaluation.
-**Galaxies:** Define the galaxy light profiles used for simulation.
-**Output:** Save the simulated dataset to FITS files.
-**Visualize:** Output subplot and image PNGs of the simulated dataset.
-**Plane Output:** Save the Galaxies object as a JSON file.
-**Info:** Save metadata (redshift, velocity dispersion) as a JSON file.
+- **Dataset Paths:** Set the output path for the simulated dataset.
+- **Grid:** Create a 2D grid for simulation.
+- **Over Sampling:** Apply adaptive over-sampling for accurate image evaluation.
+- **Galaxies:** Define the galaxy light profiles used for simulation.
+- **Output:** Save the simulated dataset to FITS files.
+- **Visualize:** Output subplot and image PNGs of the simulated dataset.
+- **Plane Output:** Save the Galaxies object as a JSON file.
+- **Info:** Save metadata (redshift, velocity dispersion) as a JSON file.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/guides/results/database/simulators/light_sersic_exp__2.py
+++ b/scripts/guides/results/database/simulators/light_sersic_exp__2.py
@@ -9,14 +9,14 @@ This script simulates `Imaging` of a galaxy using light profiles where:
 
 __Contents__
 
-**Dataset Paths:** Set the output path for the simulated dataset.
-**Grid:** Create a 2D grid for simulation.
-**Over Sampling:** Apply adaptive over-sampling for accurate image evaluation.
-**Galaxies:** Define the galaxy light profiles used for simulation.
-**Output:** Save the simulated dataset to FITS files.
-**Visualize:** Output subplot and image PNGs of the simulated dataset.
-**Plane Output:** Save the Galaxies object as a JSON file.
-**Info:** Save metadata (redshift, velocity dispersion) as a JSON file.
+- **Dataset Paths:** Set the output path for the simulated dataset.
+- **Grid:** Create a 2D grid for simulation.
+- **Over Sampling:** Apply adaptive over-sampling for accurate image evaluation.
+- **Galaxies:** Define the galaxy light profiles used for simulation.
+- **Output:** Save the simulated dataset to FITS files.
+- **Visualize:** Output subplot and image PNGs of the simulated dataset.
+- **Plane Output:** Save the Galaxies object as a JSON file.
+- **Info:** Save metadata (redshift, velocity dispersion) as a JSON file.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/guides/results/database/start_here.py
+++ b/scripts/guides/results/database/start_here.py
@@ -18,17 +18,17 @@ to illustrate the database in the database tutorials that follow.
 
 __Contents__
 
-**Unique Identifiers:** How unique identifiers ensure separate results for each dataset.
-**Dataset:** Load datasets and fit them with a non-linear search.
-**Results From Hard Disk:** Output results to hard-disk and build the database from them.
-**Building a Database File From an Output Folder:** Create a .sqlite database from output folders.
-**Writing Directly To Database:** Write results directly to the database, skipping hard-disk output.
-**Files:** The output files stored in the database and accessible via the aggregator.
-**Generators:** How Python generators provide memory-efficient access to database results.
-**Model:** Load and inspect the model used for each fit.
-**Search:** Load and inspect the non-linear search settings.
-**Samples:** Access the full non-linear search samples from the database.
-**Wrap Up:** Summary of how to use the database for result analysis.
+- **Unique Identifiers:** How unique identifiers ensure separate results for each dataset.
+- **Dataset:** Load datasets and fit them with a non-linear search.
+- **Results From Hard Disk:** Output results to hard-disk and build the database from them.
+- **Building a Database File From an Output Folder:** Create a .sqlite database from output folders.
+- **Writing Directly To Database:** Write results directly to the database, skipping hard-disk output.
+- **Files:** The output files stored in the database and accessible via the aggregator.
+- **Generators:** How Python generators provide memory-efficient access to database results.
+- **Model:** Load and inspect the model used for each fit.
+- **Search:** Load and inspect the non-linear search settings.
+- **Samples:** Access the full non-linear search samples from the database.
+- **Wrap Up:** Summary of how to use the database for result analysis.
 
 __Model__
 

--- a/scripts/guides/results/start_here.py
+++ b/scripts/guides/results/start_here.py
@@ -51,8 +51,8 @@ Each completed fit lives at a path like::
 
 __Contents__
 
-**Model Fit:** Run a quick fit once so both halves of this guide have a real result on disk to read from.
-**Info:** Print the result in a readable format.
+- **Model Fit:** Run a quick fit once so both halves of this guide have a real result on disk to read from.
+- **Info:** Print the result in a readable format.
 
 **Simple Loading (one fit at a time):**
 

--- a/scripts/guides/results/workflow/csv_make.py
+++ b/scripts/guides/results/workflow/csv_make.py
@@ -12,17 +12,17 @@ can also be easily passed on to other collaborators.
 
 __Contents__
 
-**Model Fit:** Perform model-fits whose results are output for CSV extraction.
-**Workflow Paths:** Set the output path for workflow files.
-**Aggregator:** Load results using the Aggregator.
-**Adding CSV Columns:** Add columns to the CSV file for specific model parameters.
-**Saving the CSV:** Output the CSV file to disk.
-**Customizing CSV Headers:** Customize column headers for readability.
-**Maximum Likelihood Values:** Output maximum likelihood parameter values to the CSV.
-**Errors:** Output parameter error estimates at a given sigma confidence.
-**Column Label List:** Add a label column (e.g. dataset name) to the CSV.
-**Latent Variables:** Add latent (derived) variables to the CSV.
-**Computed Columns:** Add custom computed columns derived from the samples.
+- **Model Fit:** Perform model-fits whose results are output for CSV extraction.
+- **Workflow Paths:** Set the output path for workflow files.
+- **Aggregator:** Load results using the Aggregator.
+- **Adding CSV Columns:** Add columns to the CSV file for specific model parameters.
+- **Saving the CSV:** Output the CSV file to disk.
+- **Customizing CSV Headers:** Customize column headers for readability.
+- **Maximum Likelihood Values:** Output maximum likelihood parameter values to the CSV.
+- **Errors:** Output parameter error estimates at a given sigma confidence.
+- **Column Label List:** Add a label column (e.g. dataset name) to the CSV.
+- **Latent Variables:** Add latent (derived) variables to the CSV.
+- **Computed Columns:** Add custom computed columns derived from the samples.
 
 __CSV, Png and Fits__
 

--- a/scripts/guides/results/workflow/fits_make.py
+++ b/scripts/guides/results/workflow/fits_make.py
@@ -24,15 +24,15 @@ Internally, splicing uses standard Astorpy functions to open, edit and save .fit
 
 __Contents__
 
-**Model Fit:** Perform model-fits whose results are output for FITS extraction.
-**Workflow Paths:** Set the output path for workflow FITS files.
-**Aggregator:** Load results using the Aggregator.
-**Extract Images:** Extract specific HDU images from fit.fits files.
-**Output Single Fits:** Save extracted HDUs as a single combined FITS file.
-**Output to Folder:** Save individual FITS files for each model-fit to a folder.
-**CSV Files:** Extract data from CSV files (e.g. pixelization reconstructions) and interpolate to FITS.
-**Add Extra Fits:** Add additional FITS images to the extracted file.
-**Custom Fits Files in Analysis:** Extend the Analysis class to output custom FITS images.
+- **Model Fit:** Perform model-fits whose results are output for FITS extraction.
+- **Workflow Paths:** Set the output path for workflow FITS files.
+- **Aggregator:** Load results using the Aggregator.
+- **Extract Images:** Extract specific HDU images from fit.fits files.
+- **Output Single Fits:** Save extracted HDUs as a single combined FITS file.
+- **Output to Folder:** Save individual FITS files for each model-fit to a folder.
+- **CSV Files:** Extract data from CSV files (e.g. pixelization reconstructions) and interpolate to FITS.
+- **Add Extra Fits:** Add additional FITS images to the extracted file.
+- **Custom Fits Files in Analysis:** Extend the Analysis class to output custom FITS images.
 
 __CSV, Png and Fits__
 

--- a/scripts/guides/results/workflow/png_make.py
+++ b/scripts/guides/results/workflow/png_make.py
@@ -26,17 +26,17 @@ capabilities.
 
 __Contents__
 
-**Model Fit:** Perform model-fits whose results are output for PNG extraction.
-**Workflow Paths:** Set the output path for workflow PNG files.
-**Aggregator:** Load results using the Aggregator.
-**Extract Images:** Extract specific images from subplot PNG files.
-**Output Single Png:** Save extracted images as a single combined PNG file.
-**Output to Folder:** Save individual PNG files for each model-fit to a folder.
-**Combine Images From Subplots:** Combine images from different subplots into one figure.
-**Add Extra Png:** Add additional PNG images (e.g. RGB) to a subplot.
-**Shape Customization:** Customize the size and layout of added images.
-**Zoom Png:** Zoom into a specific region of an image.
-**Custom Subplots in Analysis:** Extend the Analysis class to output custom subplot images.
+- **Model Fit:** Perform model-fits whose results are output for PNG extraction.
+- **Workflow Paths:** Set the output path for workflow PNG files.
+- **Aggregator:** Load results using the Aggregator.
+- **Extract Images:** Extract specific images from subplot PNG files.
+- **Output Single Png:** Save extracted images as a single combined PNG file.
+- **Output to Folder:** Save individual PNG files for each model-fit to a folder.
+- **Combine Images From Subplots:** Combine images from different subplots into one figure.
+- **Add Extra Png:** Add additional PNG images (e.g. RGB) to a subplot.
+- **Shape Customization:** Customize the size and layout of added images.
+- **Zoom Png:** Zoom into a specific region of an image.
+- **Custom Subplots in Analysis:** Extend the Analysis class to output custom subplot images.
 
 __CSV, Png and Fits__
 

--- a/scripts/guides/units/cosmology.py
+++ b/scripts/guides/units/cosmology.py
@@ -9,10 +9,10 @@ This is used on a variety of important cosmological quantities for example the e
 
 __Contents__
 
-**Errors:** How to produce errors on unit-converted quantities via marginalization.
-**Galaxy:** Set up a galaxy and grid to illustrate unit conversions.
-**Arcsec to Kiloparsec:** Convert angular distances to physical distances using a cosmological model.
-**Brightness Units / Luminosity:** Convert image units and compute the total luminosity of a galaxy.
+- **Errors:** How to produce errors on unit-converted quantities via marginalization.
+- **Galaxy:** Set up a galaxy and grid to illustrate unit conversions.
+- **Arcsec to Kiloparsec:** Convert angular distances to physical distances using a cosmological model.
+- **Brightness Units / Luminosity:** Convert image units and compute the total luminosity of a galaxy.
 
 __Errors__
 

--- a/scripts/guides/units/flux.py
+++ b/scripts/guides/units/flux.py
@@ -23,8 +23,8 @@ unit, like a solar luminosity or AB magnitude, it becomes a lot more straightfor
 
 __Contents__
 
-**Zero Point:** Explanation of photometric zero points and their role in flux calibration.
-**Mega Janskys / steradian (MJy/sr): James Webb Space Telescope:** Convert JWST NIRCam light profile intensities to AB magnitudes.
+- **Zero Point:** Explanation of photometric zero points and their role in flux calibration.
+- **Mega Janskys / steradian (MJy/sr): James Webb Space Telescope:** Convert JWST NIRCam light profile intensities to AB magnitudes.
 
 __Zero Point__
 

--- a/scripts/imaging/data_preparation.py
+++ b/scripts/imaging/data_preparation.py
@@ -23,16 +23,16 @@ It is absolutely vital you use the correct pixel scale, so double check this val
 
 __Contents__
 
-**Pixel Scale:** Overview of the pixel-to-arcsecond conversion factor for common telescopes.
-**Image:** Standards for the galaxy image, including units, centering and stamp size.
-**Noise Map:** Standards for the RMS noise-map, including units and values.
-**PSF:** Standards for the Point Spread Function, including size, oddness, normalization and centering.
-**Data Processing Complete:** Summary of required standards and introduction to optional steps.
-**Mask (Optional):** Creating custom masks tailored to the galaxy emission.
-**Light Centre (Optional):** Marking the galaxy light centre for use as a fixed model parameter.
-**Extra Galaxies (Optional):** Marking centres of nearby extra galaxies for modeling or masking.
-**Mask Extra Galaxies (Optional):** Creating a mask to remove extra galaxy emission from the analysis.
-**Info (Optional):** Storing auxiliary information about the dataset as a JSON file.
+- **Pixel Scale:** Overview of the pixel-to-arcsecond conversion factor for common telescopes.
+- **Image:** Standards for the galaxy image, including units, centering and stamp size.
+- **Noise Map:** Standards for the RMS noise-map, including units and values.
+- **PSF:** Standards for the Point Spread Function, including size, oddness, normalization and centering.
+- **Data Processing Complete:** Summary of required standards and introduction to optional steps.
+- **Mask (Optional):** Creating custom masks tailored to the galaxy emission.
+- **Light Centre (Optional):** Marking the galaxy light centre for use as a fixed model parameter.
+- **Extra Galaxies (Optional):** Marking centres of nearby extra galaxies for modeling or masking.
+- **Mask Extra Galaxies (Optional):** Creating a mask to remove extra galaxy emission from the analysis.
+- **Info (Optional):** Storing auxiliary information about the dataset as a JSON file.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/data_preparation/examples/data.py
+++ b/scripts/imaging/data_preparation/examples/data.py
@@ -27,10 +27,10 @@ If any code in this script is unclear, refer to the `data_preparation/start_here
 
 __Contents__
 
-**Loading Data From Individual Fits Files:** Loading an image from FITS files and inspecting its standards.
-**Converting Data To Electrons Per Second:** Converting image flux units between electrons per second, counts and ADUs.
-**Resizing Data:** Trimming or padding a large postage stamp to an appropriate size.
-**Background Subtraction:** Overview of background sky subtraction tools and modeling approaches.
+- **Loading Data From Individual Fits Files:** Loading an image from FITS files and inspecting its standards.
+- **Converting Data To Electrons Per Second:** Converting image flux units between electrons per second, counts and ADUs.
+- **Resizing Data:** Trimming or padding a large postage stamp to an appropriate size.
+- **Background Subtraction:** Overview of background sky subtraction tools and modeling approaches.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/data_preparation/examples/noise_map.py
+++ b/scripts/imaging/data_preparation/examples/noise_map.py
@@ -31,9 +31,9 @@ If any code in this script is unclear, refer to the `data_preparation/start_here
 
 __Contents__
 
-**Loading Data From Individual Fits Files:** Loading a noise-map from FITS files and inspecting its standards.
-**1) Tools Illustrated In Image:** Overview of unit conversion and resizing tools from the image preparation script.
-**Noise Conversions:** Functions for computing noise-maps from various input formats.
+- **Loading Data From Individual Fits Files:** Loading a noise-map from FITS files and inspecting its standards.
+- **1) Tools Illustrated In Image:** Overview of unit conversion and resizing tools from the image preparation script.
+- **Noise Conversions:** Functions for computing noise-maps from various input formats.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/data_preparation/examples/optional/extra_galaxies_centres.py
+++ b/scripts/imaging/data_preparation/examples/optional/extra_galaxies_centres.py
@@ -38,9 +38,9 @@ If any code in this script is unclear, refer to the `data_preparation/start_here
 
 __Contents__
 
-**Masking Extra Galaxies:** Overview of the alternative masking approach for extra galaxy emission.
-**Links / Resources:** Links to GUI tools and modeling scripts for extra galaxies.
-**Output:** Saving extra galaxy centres as a PNG and JSON file.
+- **Masking Extra Galaxies:** Overview of the alternative masking approach for extra galaxy emission.
+- **Links / Resources:** Links to GUI tools and modeling scripts for extra galaxies.
+- **Output:** Saving extra galaxy centres as a PNG and JSON file.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/data_preparation/examples/optional/mask_extra_galaxies.py
+++ b/scripts/imaging/data_preparation/examples/optional/mask_extra_galaxies.py
@@ -37,8 +37,8 @@ If any code in this script is unclear, refer to the `data_preparation/start_here
 
 __Contents__
 
-**Links / Resources:** Links to GUI tools and modeling scripts for extra galaxies masks.
-**Output:** Saving the extra galaxies mask as a FITS file.
+- **Links / Resources:** Links to GUI tools and modeling scripts for extra galaxies masks.
+- **Output:** Saving the extra galaxies mask as a FITS file.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/data_preparation/examples/psf.py
+++ b/scripts/imaging/data_preparation/examples/psf.py
@@ -31,10 +31,10 @@ If any code in this script is unclear, refer to the `data_preparation/start_here
 
 __Contents__
 
-**Loading Data From Individual Fits Files:** Loading a PSF from FITS files and inspecting its standards.
-**1) PSF Size:** Resizing the PSF kernel to an appropriate size for efficient convolution.
-**PSF Dimensions:** Ensuring the PSF has odd dimensions to avoid half-pixel offsets.
-**PSF Normalization:** Normalizing the PSF kernel so all values sum to unity.
+- **Loading Data From Individual Fits Files:** Loading a PSF from FITS files and inspecting its standards.
+- **1) PSF Size:** Resizing the PSF kernel to an appropriate size for efficient convolution.
+- **PSF Dimensions:** Ensuring the PSF has odd dimensions to avoid half-pixel offsets.
+- **PSF Normalization:** Normalizing the PSF kernel so all values sum to unity.
 """
 
 # %matplotlib

--- a/scripts/imaging/data_preparation/gui/extra_galaxies_centres.py
+++ b/scripts/imaging/data_preparation/gui/extra_galaxies_centres.py
@@ -15,10 +15,10 @@ above which requires you to input these values manually.
 
 __Contents__
 
-**Dataset:** Loading the imaging dataset for extra galaxy centre marking.
-**Search Box:** Configuring the pixel search area around each click.
-**Clicker:** Using the interactive GUI to click on extra galaxy centres.
-**Output:** Saving the extra galaxy centres as a JSON file and PNG visualization.
+- **Dataset:** Loading the imaging dataset for extra galaxy centre marking.
+- **Search Box:** Configuring the pixel search area around each click.
+- **Clicker:** Using the interactive GUI to click on extra galaxy centres.
+- **Output:** Saving the extra galaxy centres as a JSON file and PNG visualization.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/data_preparation/gui/light_centre.py
+++ b/scripts/imaging/data_preparation/gui/light_centre.py
@@ -9,10 +9,10 @@ value in pipelines.
 
 __Contents__
 
-**Dataset:** Loading the imaging dataset for light centre marking.
-**Search Box:** Configuring the pixel search area around each click.
-**Clicker:** Using the interactive GUI to click on galaxy light centres.
-**Output:** Saving the light centres as a JSON file and PNG visualization.
+- **Dataset:** Loading the imaging dataset for light centre marking.
+- **Search Box:** Configuring the pixel search area around each click.
+- **Clicker:** Using the interactive GUI to click on galaxy light centres.
+- **Output:** Saving the light centres as a JSON file and PNG visualization.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/data_preparation/gui/mask.py
+++ b/scripts/imaging/data_preparation/gui/mask.py
@@ -10,9 +10,9 @@ This GUI is adapted from the following code: https://gist.github.com/brikeats/4f
 
 __Contents__
 
-**Dataset:** Loading the imaging dataset for mask creation.
-**Scribbler:** Using the interactive GUI to draw the mask.
-**Output:** Saving the mask as a FITS file and PNG visualization.
+- **Dataset:** Loading the imaging dataset for mask creation.
+- **Scribbler:** Using the interactive GUI to draw the mask.
+- **Output:** Saving the mask as a FITS file and PNG visualization.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/data_preparation/gui/mask_extra_galaxies.py
+++ b/scripts/imaging/data_preparation/gui/mask_extra_galaxies.py
@@ -15,10 +15,10 @@ example above which requires you to input these values manually.
 
 __Contents__
 
-**Dataset:** Loading the imaging dataset for extra galaxy mask creation.
-**Mask:** Creating a circular mask overlay to guide the spray painting.
-**Scribbler:** Using the interactive GUI to spray paint extra galaxy regions.
-**Output:** Saving the extra galaxies mask as a FITS file and PNG visualization.
+- **Dataset:** Loading the imaging dataset for extra galaxy mask creation.
+- **Mask:** Creating a circular mask overlay to guide the spray painting.
+- **Scribbler:** Using the interactive GUI to spray paint extra galaxy regions.
+- **Output:** Saving the extra galaxies mask as a FITS file and PNG visualization.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/data_preparation/start_here.py
+++ b/scripts/imaging/data_preparation/start_here.py
@@ -23,15 +23,15 @@ It is absolutely vital you use the correct pixel scale, so double check this val
 
 __Contents__
 
-**Image:** Standards for the galaxy image, including units, centering and stamp size.
-**Noise Map:** Standards for the RMS noise-map, including units and values.
-**PSF:** Standards for the Point Spread Function, including size, oddness, normalization and centering.
-**Data Processing Complete:** Summary of required standards and introduction to optional steps.
-**Mask (Optional):** Creating custom masks tailored to the galaxy emission.
-**Light Centre (Optional):** Marking the galaxy light centre for use as a fixed model parameter.
-**Extra Galaxies (Optional):** Marking centres of nearby extra galaxies for modeling or masking.
-**Mask Extra Galaxies (Optional):** Creating a mask to remove extra galaxy emission from the analysis.
-**Info (Optional):** Storing auxiliary information about the dataset as a JSON file.
+- **Image:** Standards for the galaxy image, including units, centering and stamp size.
+- **Noise Map:** Standards for the RMS noise-map, including units and values.
+- **PSF:** Standards for the Point Spread Function, including size, oddness, normalization and centering.
+- **Data Processing Complete:** Summary of required standards and introduction to optional steps.
+- **Mask (Optional):** Creating custom masks tailored to the galaxy emission.
+- **Light Centre (Optional):** Marking the galaxy light centre for use as a fixed model parameter.
+- **Extra Galaxies (Optional):** Marking centres of nearby extra galaxies for modeling or masking.
+- **Mask Extra Galaxies (Optional):** Creating a mask to remove extra galaxy emission from the analysis.
+- **Info (Optional):** Storing auxiliary information about the dataset as a JSON file.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/features/extra_galaxies/modeling.py
+++ b/scripts/imaging/features/extra_galaxies/modeling.py
@@ -38,23 +38,23 @@ If any code in this script is unclear, refer to the `modeling/start_here.ipynb` 
 
 __Contents__
 
-**Dataset:** Loading the extra galaxies imaging dataset from FITS files.
-**Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
-**Mask:** Defining a larger 6.0 arcsecond circular mask to include extra galaxy emission.
-**Extra Galaxies Over Sampling:** Applying adaptive over-sampling at the centres of all galaxies.
-**Extra Galaxies Noise Scaling:** Scaling noise to remove extra galaxy emission without masking pixels.
-**Extra Galaxies Dataset:** Reloading the dataset without noise scaling for the modeling approach.
-**Extra Galaxies Centres:** Loading the extra galaxy centre coordinates from a JSON file.
-**Model:** Composing the galaxy model with Sersic bulge and Exponential disk.
-**Extra Galaxies Model:** Adding extra galaxy light profiles with fixed centres to the model.
-**Search + Analysis:** Configuring the Nautilus search and analysis for the model-fit.
-**VRAM:** Discussion of GPU VRAM usage with extra galaxy components.
-**Run Time:** Discussion of computational run times with extra galaxies.
-**Model-Fit:** Running the model-fit with the extra galaxies included.
-**Result:** Inspecting the model-fit results and best-fit model.
-**Approaches to Extra Galaxies:** Summary of masking vs modeling approaches for extra galaxies.
-**Multi Gaussian Expansion:** Using MGE as an alternative to Sersic profiles for extra galaxies.
-**Wrap Up:** Summary and links to further resources.
+- **Dataset:** Loading the extra galaxies imaging dataset from FITS files.
+- **Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
+- **Mask:** Defining a larger 6.0 arcsecond circular mask to include extra galaxy emission.
+- **Extra Galaxies Over Sampling:** Applying adaptive over-sampling at the centres of all galaxies.
+- **Extra Galaxies Noise Scaling:** Scaling noise to remove extra galaxy emission without masking pixels.
+- **Extra Galaxies Dataset:** Reloading the dataset without noise scaling for the modeling approach.
+- **Extra Galaxies Centres:** Loading the extra galaxy centre coordinates from a JSON file.
+- **Model:** Composing the galaxy model with Sersic bulge and Exponential disk.
+- **Extra Galaxies Model:** Adding extra galaxy light profiles with fixed centres to the model.
+- **Search + Analysis:** Configuring the Nautilus search and analysis for the model-fit.
+- **VRAM:** Discussion of GPU VRAM usage with extra galaxy components.
+- **Run Time:** Discussion of computational run times with extra galaxies.
+- **Model-Fit:** Running the model-fit with the extra galaxies included.
+- **Result:** Inspecting the model-fit results and best-fit model.
+- **Approaches to Extra Galaxies:** Summary of masking vs modeling approaches for extra galaxies.
+- **Multi Gaussian Expansion:** Using MGE as an alternative to Sersic profiles for extra galaxies.
+- **Wrap Up:** Summary and links to further resources.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/imaging/features/extra_galaxies/simulator.py
+++ b/scripts/imaging/features/extra_galaxies/simulator.py
@@ -50,14 +50,14 @@ If any code in this script is unclear, refer to the `simulators/start_here.ipynb
 
 __Contents__
 
-**Dataset Paths:** Defining the output path for the simulated dataset.
-**Grid:** Setting up the 2D grid with adaptive over-sampling for all galaxy centres.
-**Galaxies:** Defining the main galaxy with Sersic bulge and Exponential disk light profiles.
-**Extra Galaxies:** Defining two extra galaxies with spherical Exponential light profiles.
-**Output:** Saving the simulated dataset to FITS files.
-**Visualize:** Outputting subplot and image visualizations as PNG files.
-**Mask Extra Galaxies:** Building and saving `mask_extra_galaxies.fits` so consumers can load it directly.
-**Plane Output:** Saving the Galaxies object as a JSON file for future reference.
+- **Dataset Paths:** Defining the output path for the simulated dataset.
+- **Grid:** Setting up the 2D grid with adaptive over-sampling for all galaxy centres.
+- **Galaxies:** Defining the main galaxy with Sersic bulge and Exponential disk light profiles.
+- **Extra Galaxies:** Defining two extra galaxies with spherical Exponential light profiles.
+- **Output:** Saving the simulated dataset to FITS files.
+- **Visualize:** Outputting subplot and image visualizations as PNG files.
+- **Mask Extra Galaxies:** Building and saving `mask_extra_galaxies.fits` so consumers can load it directly.
+- **Plane Output:** Saving the Galaxies object as a JSON file for future reference.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/features/linear_light_profiles/fit.py
+++ b/scripts/imaging/features/linear_light_profiles/fit.py
@@ -12,13 +12,13 @@ light profiles!
 
 __Contents__
 
-**Advantages & Disadvatanges:** Benefits and drawbacks of linear light profiles.
-**Positive Only Solver:** How a positive solution to the light profile intensities is ensured.
-**Dataset & Mask:** Standard set up of imaging dataset that is fitted.
-**Fit:** Perform a fit to a dataset using linear light profile with inputs for other light profile parameters.
-**Intensities:** Access the solved for intensities of light profiles from the fit.
-**Visualization:** Plotting images of model-fits using linear light profiles.
-**Linear Objects (Source Code)**: Internal source code implementation of linear light profiles (for contributors).
+- **Advantages & Disadvatanges:** Benefits and drawbacks of linear light profiles.
+- **Positive Only Solver:** How a positive solution to the light profile intensities is ensured.
+- **Dataset & Mask:** Standard set up of imaging dataset that is fitted.
+- **Fit:** Perform a fit to a dataset using linear light profile with inputs for other light profile parameters.
+- **Intensities:** Access the solved for intensities of light profiles from the fit.
+- **Visualization:** Plotting images of model-fits using linear light profiles.
+- **Linear Objects (Source Code)**: Internal source code implementation of linear light profiles (for contributors).
 
 __Advantages__
 

--- a/scripts/imaging/features/linear_light_profiles/likelihood_function.py
+++ b/scripts/imaging/features/linear_light_profiles/likelihood_function.py
@@ -28,25 +28,25 @@ therefore you must read the following notebooks before this script:
 
 __Contents__
 
-**Dataset:** Loading the imaging dataset for likelihood evaluation.
-**Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
-**Masked Image Grid:** Setting up the 2D grid of masked image-pixel coordinates.
-**Linear Light Profiles:** Defining linear Sersic and Exponential light profiles without intensity parameters.
-**LightProfileLinearObjFuncList:** Creating the interface between linear light profiles and the linear algebra.
-**Mapping Matrix:** Computing the mapping matrix of light profile images.
-**Blurred Mapping Matrix ($f$):** Computing the PSF-convolved mapping matrix.
-**Data Vector (D):** Computing the data vector for the linear inversion.
-**Curvature Matrix (F):** Computing the curvature matrix for the linear inversion.
-**Reconstruction (Positive-Negative):** Solving the linear algebra allowing positive and negative intensity values.
-**Reconstruction (Positive Only):** Solving the linear algebra with a positive-only constraint.
-**Image Reconstruction:** Mapping the reconstruction back to the image plane.
-**Likelihood Function:** Overview of the log likelihood function terms.
-**Chi Squared:** Computing the chi-squared statistic for the fit.
-**Noise Normalization Term:** Computing the noise normalization term of the likelihood.
-**Calculate The Log Likelihood:** Combining terms to compute the final log likelihood value.
-**Fit:** Performing the same likelihood evaluation using the FitImaging object.
-**Galaxy Modeling:** Brief description of how the likelihood is sampled by a non-linear search.
-**Wrap Up:** Summary and links to additional guides.
+- **Dataset:** Loading the imaging dataset for likelihood evaluation.
+- **Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
+- **Masked Image Grid:** Setting up the 2D grid of masked image-pixel coordinates.
+- **Linear Light Profiles:** Defining linear Sersic and Exponential light profiles without intensity parameters.
+- **LightProfileLinearObjFuncList:** Creating the interface between linear light profiles and the linear algebra.
+- **Mapping Matrix:** Computing the mapping matrix of light profile images.
+- **Blurred Mapping Matrix ($f$):** Computing the PSF-convolved mapping matrix.
+- **Data Vector (D):** Computing the data vector for the linear inversion.
+- **Curvature Matrix (F):** Computing the curvature matrix for the linear inversion.
+- **Reconstruction (Positive-Negative):** Solving the linear algebra allowing positive and negative intensity values.
+- **Reconstruction (Positive Only):** Solving the linear algebra with a positive-only constraint.
+- **Image Reconstruction:** Mapping the reconstruction back to the image plane.
+- **Likelihood Function:** Overview of the log likelihood function terms.
+- **Chi Squared:** Computing the chi-squared statistic for the fit.
+- **Noise Normalization Term:** Computing the noise normalization term of the likelihood.
+- **Calculate The Log Likelihood:** Combining terms to compute the final log likelihood value.
+- **Fit:** Performing the same likelihood evaluation using the FitImaging object.
+- **Galaxy Modeling:** Brief description of how the likelihood is sampled by a non-linear search.
+- **Wrap Up:** Summary and links to additional guides.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/features/linear_light_profiles/modeling.py
+++ b/scripts/imaging/features/linear_light_profiles/modeling.py
@@ -12,18 +12,18 @@ light profiles!
 
 __Contents__
 
-**Advantages & Disadvatanges:** Benefits and drawbacks of linear light profiles.
-**Positive Only Solver:** How a positive solution to the light profile intensities is ensured.
-**Dataset & Mask:** Standard set up of imaging dataset that is fitted.
-**Fit:** Perform a fit to a dataset using linear light profile with inputs for other light profile parameters.
-**Intensities:** Access the solved for intensities of light profiles from the fit.
-**Model:** Composing a model using linear light profiles and how it changes the number of free parameters.
-**Search & Analysis:** Standard set up of non-linear search and analysis.
-**Run Time:** Profiling of linear light profile run times and discussion of how they compare to standard light profiles.
-**Model-Fit:** Performs the model fit using standard API.
-**Result & Intensities:** Linear light profiles results, including how to access light profiles with solved for intensity values.
-**Visualization:** Plotting images of model-fits using linear light profiles.
-**Linear Objects (Source Code)**: Internal source code implementation of linear light profiles (for contributors).
+- **Advantages & Disadvatanges:** Benefits and drawbacks of linear light profiles.
+- **Positive Only Solver:** How a positive solution to the light profile intensities is ensured.
+- **Dataset & Mask:** Standard set up of imaging dataset that is fitted.
+- **Fit:** Perform a fit to a dataset using linear light profile with inputs for other light profile parameters.
+- **Intensities:** Access the solved for intensities of light profiles from the fit.
+- **Model:** Composing a model using linear light profiles and how it changes the number of free parameters.
+- **Search & Analysis:** Standard set up of non-linear search and analysis.
+- **Run Time:** Profiling of linear light profile run times and discussion of how they compare to standard light profiles.
+- **Model-Fit:** Performs the model fit using standard API.
+- **Result & Intensities:** Linear light profiles results, including how to access light profiles with solved for intensity values.
+- **Visualization:** Plotting images of model-fits using linear light profiles.
+- **Linear Objects (Source Code)**: Internal source code implementation of linear light profiles (for contributors).
 
 __Advantages__
 

--- a/scripts/imaging/features/multi_gaussian_expansion/fit.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/fit.py
@@ -12,15 +12,15 @@ profiles like the `Sersic`.
 
 __Contents__
 
-**Advantages & Disadvantages:** Benefits and drawbacks of using an MGE.
-**Positive Only Solver:** How a positive solution to the light profile intensities is ensured.
-**MGE Source Galaxy:** Discussion of using the MGE for the source galaxy, which is illustrated fully at the end of the example.
-**Dataset & Mask:** Standard set up of imaging dataset that is fitted.
-**Basis:** How to create a basis of multiple light profiles, in this example Gaussians.
-**Gaussians:** A visualization of the Gaussians in the Basis that make up the MGE.
-**Linear Light Profiles:** How to create a basis of linear light profiles to perform the MGE.
-**Fit:** Perform a fit to a dataset using linear light profile MGE.
-**Intensities:** Access the solved for intensities of linear light profiles from the fit.
+- **Advantages & Disadvantages:** Benefits and drawbacks of using an MGE.
+- **Positive Only Solver:** How a positive solution to the light profile intensities is ensured.
+- **MGE Source Galaxy:** Discussion of using the MGE for the source galaxy, which is illustrated fully at the end of the example.
+- **Dataset & Mask:** Standard set up of imaging dataset that is fitted.
+- **Basis:** How to create a basis of multiple light profiles, in this example Gaussians.
+- **Gaussians:** A visualization of the Gaussians in the Basis that make up the MGE.
+- **Linear Light Profiles:** How to create a basis of linear light profiles to perform the MGE.
+- **Fit:** Perform a fit to a dataset using linear light profile MGE.
+- **Intensities:** Access the solved for intensities of linear light profiles from the fit.
 
 __Advantages__
 

--- a/scripts/imaging/features/multi_gaussian_expansion/likelihood_function.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/likelihood_function.py
@@ -27,27 +27,27 @@ linear light profiles, therefore you must read the following notebooks before th
 
 __Contents__
 
-**Dataset:** Loading the imaging dataset for likelihood evaluation.
-**Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
-**Masked Image Grid:** Setting up the 2D grid of masked image-pixel coordinates.
-**Multiple Gaussians & Linear Light Profiles:** Creating 30 linear Gaussian light profiles for the MGE.
-**Basis:** Grouping the Gaussians into a Basis object for the multi-Gaussian expansion.
-**Comparison To Linear Light Profiles Example:** Key differences from the linear light profile likelihood function.
-**LightProfileLinearObjFuncList:** Creating the interface between the Basis and linear algebra.
-**Mapping Matrix:** Computing the mapping matrix of Gaussian light profile images.
-**Blurred Mapping Matrix ($f$):** Computing the PSF-convolved mapping matrix.
-**Data Vector (D):** Computing the data vector for the linear inversion.
-**Curvature Matrix (F):** Computing the curvature matrix for the linear inversion.
-**Reconstruction (Positive-Negative):** Solving the linear algebra allowing positive and negative intensity values.
-**Reconstruction (Positive Only):** Solving with a positive-only constraint and zeroth-order regularization.
-**Image Reconstruction:** Mapping the reconstruction back to the image plane.
-**Likelihood Function:** Overview of the log likelihood function terms.
-**Chi Squared:** Computing the chi-squared statistic for the fit.
-**Noise Normalization Term:** Computing the noise normalization term of the likelihood.
-**Calculate The Log Likelihood:** Combining terms to compute the final log likelihood value.
-**Fit:** Performing the same likelihood evaluation using the FitImaging object.
-**Galaxy Modeling:** Brief description of how the likelihood is sampled by a non-linear search.
-**Wrap Up:** Summary and links to additional guides.
+- **Dataset:** Loading the imaging dataset for likelihood evaluation.
+- **Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
+- **Masked Image Grid:** Setting up the 2D grid of masked image-pixel coordinates.
+- **Multiple Gaussians & Linear Light Profiles:** Creating 30 linear Gaussian light profiles for the MGE.
+- **Basis:** Grouping the Gaussians into a Basis object for the multi-Gaussian expansion.
+- **Comparison To Linear Light Profiles Example:** Key differences from the linear light profile likelihood function.
+- **LightProfileLinearObjFuncList:** Creating the interface between the Basis and linear algebra.
+- **Mapping Matrix:** Computing the mapping matrix of Gaussian light profile images.
+- **Blurred Mapping Matrix ($f$):** Computing the PSF-convolved mapping matrix.
+- **Data Vector (D):** Computing the data vector for the linear inversion.
+- **Curvature Matrix (F):** Computing the curvature matrix for the linear inversion.
+- **Reconstruction (Positive-Negative):** Solving the linear algebra allowing positive and negative intensity values.
+- **Reconstruction (Positive Only):** Solving with a positive-only constraint and zeroth-order regularization.
+- **Image Reconstruction:** Mapping the reconstruction back to the image plane.
+- **Likelihood Function:** Overview of the log likelihood function terms.
+- **Chi Squared:** Computing the chi-squared statistic for the fit.
+- **Noise Normalization Term:** Computing the noise normalization term of the likelihood.
+- **Calculate The Log Likelihood:** Combining terms to compute the final log likelihood value.
+- **Fit:** Performing the same likelihood evaluation using the FitImaging object.
+- **Galaxy Modeling:** Brief description of how the likelihood is sampled by a non-linear search.
+- **Wrap Up:** Summary and links to additional guides.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/imaging/features/multi_gaussian_expansion/modeling.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/modeling.py
@@ -12,17 +12,17 @@ profiles like the `Sersic`.
 
 __Contents__
 
-**Advantages & Disadvantages:** Benefits and drawbacks of using an MGE.
-**Positive Only Solver:** How a positive solution to the light profile intensities is ensured.
-**MGE Source Galaxy:** Discussion of using the MGE for the source galaxy, which is illustrated fully at the end of the example.
-**Dataset & Mask:** Standard set up of imaging dataset that is fitted.
-**Model:** Composing a model using an MGE and how it changes the number of free parameters.
-**Search & Analysis:** Standard set up of non-linear search and analysis.
-**Run Time:** Profiling of MGE run times and discussion of how they compare to standard light profiles.
-**Model-Fit:** Performs the model fit using standard API.
-**Result:** MGE results, including accessing light profiles with solved for intensity values.
-**MGE Source:** Detailed illustration of using MGE source.
-**Regularization:** API for applying regularization to MGE, which is not recommend but included for illustration.
+- **Advantages & Disadvantages:** Benefits and drawbacks of using an MGE.
+- **Positive Only Solver:** How a positive solution to the light profile intensities is ensured.
+- **MGE Source Galaxy:** Discussion of using the MGE for the source galaxy, which is illustrated fully at the end of the example.
+- **Dataset & Mask:** Standard set up of imaging dataset that is fitted.
+- **Model:** Composing a model using an MGE and how it changes the number of free parameters.
+- **Search & Analysis:** Standard set up of non-linear search and analysis.
+- **Run Time:** Profiling of MGE run times and discussion of how they compare to standard light profiles.
+- **Model-Fit:** Performs the model fit using standard API.
+- **Result:** MGE results, including accessing light profiles with solved for intensity values.
+- **MGE Source:** Detailed illustration of using MGE source.
+- **Regularization:** API for applying regularization to MGE, which is not recommend but included for illustration.
 
 __Advantages__
 

--- a/scripts/imaging/features/multi_gaussian_expansion/simulator.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/simulator.py
@@ -17,12 +17,12 @@ If any code in this script is unclear, refer to the `simulators/start_here.ipynb
 
 __Contents__
 
-**Dataset Paths:** Defining the output path for the simulated dataset.
-**Grid:** Setting up the 2D grid with adaptive over-sampling for simulation.
-**Galaxies:** Defining the galaxy using a basis of 14 Gaussian light profiles from an MGE fit.
-**Output:** Saving the simulated dataset to FITS files.
-**Visualize:** Outputting subplot and image visualizations as PNG files.
-**Plane Output:** Saving the Galaxies object as a JSON file for future reference.
+- **Dataset Paths:** Defining the output path for the simulated dataset.
+- **Grid:** Setting up the 2D grid with adaptive over-sampling for simulation.
+- **Galaxies:** Defining the galaxy using a basis of 14 Gaussian light profiles from an MGE fit.
+- **Output:** Saving the simulated dataset to FITS files.
+- **Visualize:** Outputting subplot and image visualizations as PNG files.
+- **Plane Output:** Saving the Galaxies object as a JSON file for future reference.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/features/operated_light_profile/modeling.py
+++ b/scripts/imaging/features/operated_light_profile/modeling.py
@@ -45,17 +45,17 @@ If any code in this script is unclear, refer to the `modeling/start_here.ipynb` 
 
 __Contents__
 
-**Dataset:** Loading the operated light profile imaging dataset from FITS files.
-**Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
-**Mask:** Applying a circular mask to the dataset.
-**Over Sampling:** Applying adaptive over-sampling for accurate light profile evaluation.
-**Model:** Composing the galaxy model with a linear Sersic bulge and operated Gaussian point source.
-**Search:** Configuring the Nautilus nested sampling non-linear search.
-**Analysis:** Creating the AnalysisImaging object for likelihood evaluation.
-**VRAM:** Discussion of GPU VRAM usage for operated light profiles.
-**Run Time:** Discussion of computational run times for operated light profiles.
-**Model-Fit:** Running the model-fit and monitoring output.
-**Result:** Inspecting the result object and best-fit model.
+- **Dataset:** Loading the operated light profile imaging dataset from FITS files.
+- **Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
+- **Mask:** Applying a circular mask to the dataset.
+- **Over Sampling:** Applying adaptive over-sampling for accurate light profile evaluation.
+- **Model:** Composing the galaxy model with a linear Sersic bulge and operated Gaussian point source.
+- **Search:** Configuring the Nautilus nested sampling non-linear search.
+- **Analysis:** Creating the AnalysisImaging object for likelihood evaluation.
+- **VRAM:** Discussion of GPU VRAM usage for operated light profiles.
+- **Run Time:** Discussion of computational run times for operated light profiles.
+- **Model-Fit:** Running the model-fit and monitoring output.
+- **Result:** Inspecting the result object and best-fit model.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/features/operated_light_profile/simulator.py
+++ b/scripts/imaging/features/operated_light_profile/simulator.py
@@ -18,12 +18,12 @@ If any code in this script is unclear, refer to the `simulators/start_here.ipynb
 
 __Contents__
 
-**Dataset Paths:** Defining the output path for the simulated dataset.
-**Grid:** Setting up the 2D grid with adaptive over-sampling for simulation.
-**Galaxies:** Defining the galaxy with a Sersic bulge and an operated Gaussian point source.
-**Output:** Saving the simulated dataset to FITS files.
-**Visualize:** Outputting subplot and image visualizations as PNG files.
-**Plane Output:** Saving the Galaxies object as a JSON file for future reference.
+- **Dataset Paths:** Defining the output path for the simulated dataset.
+- **Grid:** Setting up the 2D grid with adaptive over-sampling for simulation.
+- **Galaxies:** Defining the galaxy with a Sersic bulge and an operated Gaussian point source.
+- **Output:** Saving the simulated dataset to FITS files.
+- **Visualize:** Outputting subplot and image visualizations as PNG files.
+- **Plane Output:** Saving the Galaxies object as a JSON file for future reference.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/features/pixelization/fit.py
+++ b/scripts/imaging/features/pixelization/fit.py
@@ -34,15 +34,15 @@ via the library `numba`.
 
 __Contents__
 
-**Advantages & Disadvantages:** Benefits and drawbacks of using an MGE.
-**Positive Only Solver:** How a positive solution to the light profile intensities is ensured.
-**Dataset & Mask:** Standard set up of imaging dataset that is fitted.
-**Mesh Shape**: Defining the shape of the mesh that reconstructs the source in advance, such that JAX knows static array shapes.
-**Pixelization:** How to create a pixelization, including a description of its inputs.
-**Fit:** Perform a fit to a dataset using a pixelization, and visualize its results.
-**Interpolated Source:** Interpolate the source reconstruction from an irregular Voronoi mesh to a uniform square grid and output to a .fits file.
-**Result (Advanced):** API for various pixelization outputs (magnifications, mappings) which requires some polishing.
-**Simulate (Advanced):** Simulating a dataset with the inferred pixelized source.
+- **Advantages & Disadvantages:** Benefits and drawbacks of using an MGE.
+- **Positive Only Solver:** How a positive solution to the light profile intensities is ensured.
+- **Dataset & Mask:** Standard set up of imaging dataset that is fitted.
+- **Mesh Shape**: Defining the shape of the mesh that reconstructs the source in advance, such that JAX knows static array shapes.
+- **Pixelization:** How to create a pixelization, including a description of its inputs.
+- **Fit:** Perform a fit to a dataset using a pixelization, and visualize its results.
+- **Interpolated Source:** Interpolate the source reconstruction from an irregular Voronoi mesh to a uniform square grid and output to a .fits file.
+- **Result (Advanced):** API for various pixelization outputs (magnifications, mappings) which requires some polishing.
+- **Simulate (Advanced):** Simulating a dataset with the inferred pixelized source.
 
 __Advantages__
 

--- a/scripts/imaging/features/pixelization/likelihood_function.py
+++ b/scripts/imaging/features/pixelization/likelihood_function.py
@@ -26,36 +26,36 @@ linear light profiles, therefore you must read the following notebooks before th
 
 __Contents__
 
-**Mesh Shape:** Fixing the rectangular mesh shape before modeling.
-**Dataset:** Loading the imaging dataset for likelihood evaluation.
-**Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
-**Mask:** Defining and applying a circular mask to the data.
-**Over Sampling:** Setting up over-sampling for the pixelization.
-**Masked Image Grid:** Setting up the 2D grid of masked image-pixel coordinates.
-**Galaxy:** Creating the galaxy object for the pixelized reconstruction.
-**Source Galaxy Pixelization and Regularization:** Defining the mesh and regularization for the pixelization.
-**Interpolation:** Interpolating image-pixel coordinates to source-pixel coordinates.
-**Mapper:** Creating the mapper object which maps between image and source planes.
-**Over Sampling:** Over-sampling applied to the pixelization grid.
-**Alternative Meshes:** Discussion of other mesh types available in PyAutoGalaxy.
-**Mapping Matrix:** Computing the mapping matrix from source pixels to image pixels.
-**Blurred Mapping Matrix ($f$):** Computing the PSF-convolved mapping matrix.
-**Data Vector (D):** Computing the data vector for the linear inversion.
-**Curvature Matrix (F):** Computing the curvature matrix for the linear inversion.
-**Regularization Matrix (H):** Computing the regularization matrix that enforces smoothness.
-**F + Lamdba H:** Combining the curvature and regularization matrices.
-**Galaxy Reconstruction (s):** Solving for the source pixel flux values.
-**Image Reconstruction:** Mapping the reconstruction back to the image plane.
-**Likelihood Function:** Overview of the log likelihood function terms for pixelizations.
-**Chi Squared:** Computing the chi-squared statistic for the fit.
-**Regularization Term:** Computing the regularization penalty term.
-**Complexity Terms:** Computing the Bayesian complexity terms for model comparison.
-**Noise Normalization Term:** Computing the noise normalization term of the likelihood.
-**Calculate The Log Likelihood:** Combining terms to compute the final log evidence value.
-**Fit:** Performing the same likelihood evaluation using the FitImaging object.
-**Galaxy Modeling:** Brief description of how the likelihood is sampled by a non-linear search.
-**Log Likelihood Function: Pixelization With Light Profile:** Discussion of combining pixelization with light profiles.
-**Wrap Up:** Summary and links to additional guides.
+- **Mesh Shape:** Fixing the rectangular mesh shape before modeling.
+- **Dataset:** Loading the imaging dataset for likelihood evaluation.
+- **Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
+- **Mask:** Defining and applying a circular mask to the data.
+- **Over Sampling:** Setting up over-sampling for the pixelization.
+- **Masked Image Grid:** Setting up the 2D grid of masked image-pixel coordinates.
+- **Galaxy:** Creating the galaxy object for the pixelized reconstruction.
+- **Source Galaxy Pixelization and Regularization:** Defining the mesh and regularization for the pixelization.
+- **Interpolation:** Interpolating image-pixel coordinates to source-pixel coordinates.
+- **Mapper:** Creating the mapper object which maps between image and source planes.
+- **Over Sampling:** Over-sampling applied to the pixelization grid.
+- **Alternative Meshes:** Discussion of other mesh types available in PyAutoGalaxy.
+- **Mapping Matrix:** Computing the mapping matrix from source pixels to image pixels.
+- **Blurred Mapping Matrix ($f$):** Computing the PSF-convolved mapping matrix.
+- **Data Vector (D):** Computing the data vector for the linear inversion.
+- **Curvature Matrix (F):** Computing the curvature matrix for the linear inversion.
+- **Regularization Matrix (H):** Computing the regularization matrix that enforces smoothness.
+- **F + Lamdba H:** Combining the curvature and regularization matrices.
+- **Galaxy Reconstruction (s):** Solving for the source pixel flux values.
+- **Image Reconstruction:** Mapping the reconstruction back to the image plane.
+- **Likelihood Function:** Overview of the log likelihood function terms for pixelizations.
+- **Chi Squared:** Computing the chi-squared statistic for the fit.
+- **Regularization Term:** Computing the regularization penalty term.
+- **Complexity Terms:** Computing the Bayesian complexity terms for model comparison.
+- **Noise Normalization Term:** Computing the noise normalization term of the likelihood.
+- **Calculate The Log Likelihood:** Combining terms to compute the final log evidence value.
+- **Fit:** Performing the same likelihood evaluation using the FitImaging object.
+- **Galaxy Modeling:** Brief description of how the likelihood is sampled by a non-linear search.
+- **Log Likelihood Function: Pixelization With Light Profile:** Discussion of combining pixelization with light profiles.
+- **Wrap Up:** Summary and links to additional guides.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/features/pixelization/modeling.py
+++ b/scripts/imaging/features/pixelization/modeling.py
@@ -57,19 +57,19 @@ it is worth benchmarking both approaches (GPU+JAX vs CPU+numba) to determine whi
 
 __Contents__
 
-**Advantages & Disadvantages:** Benefits and drawbacks of using a pixelization to model galaxy light.
-**Positive Only Solver:** How a positive solution to the reconstructed pixel fluxes is ensured.
-**Dataset & Mask:** Standard setup of the imaging dataset that is fitted.
-**Pixelization:** How to create a pixelization, including a description of its inputs.
-**Model:** Composing a model using a pixelization and how it changes the number of free parameters.
-**Search & Analysis:** Standard setup of non-linear search and analysis.
-**Run Time:** Profiling of pixelization run times and discussion of how they compare to analytic light profiles.
-**Model-Fit:** Performs the model fit using the standard API.
-**Result:** Pixelization results and visualization.
-**Including Smooth Components:** How to combine a pixelization with parametric light profiles to model both smooth and complex galaxy structures.
-**Chaining:** How the advanced modeling feature, non-linear search chaining, can significantly improve lens modeling with pixelizaitons.
-**Result (Advanced):** API for various pixelization outputs (magnifications, mappings) which requires some polishing.
-**Simulate (Advanced):** Simulating a strong lens dataset with the inferred pixelized source.
+- **Advantages & Disadvantages:** Benefits and drawbacks of using a pixelization to model galaxy light.
+- **Positive Only Solver:** How a positive solution to the reconstructed pixel fluxes is ensured.
+- **Dataset & Mask:** Standard setup of the imaging dataset that is fitted.
+- **Pixelization:** How to create a pixelization, including a description of its inputs.
+- **Model:** Composing a model using a pixelization and how it changes the number of free parameters.
+- **Search & Analysis:** Standard setup of non-linear search and analysis.
+- **Run Time:** Profiling of pixelization run times and discussion of how they compare to analytic light profiles.
+- **Model-Fit:** Performs the model fit using the standard API.
+- **Result:** Pixelization results and visualization.
+- **Including Smooth Components:** How to combine a pixelization with parametric light profiles to model both smooth and complex galaxy structures.
+- **Chaining:** How the advanced modeling feature, non-linear search chaining, can significantly improve lens modeling with pixelizaitons.
+- **Result (Advanced):** API for various pixelization outputs (magnifications, mappings) which requires some polishing.
+- **Simulate (Advanced):** Simulating a strong lens dataset with the inferred pixelized source.
 
 __Advantages__
 

--- a/scripts/imaging/features/pixelization/source_science.py
+++ b/scripts/imaging/features/pixelization/source_science.py
@@ -13,9 +13,9 @@ loaded to perform analysis without the need for PyAutoLens.
 
 __Contents__
 
-**Model Fit:** Running a pixelization model-fit which outputs the source reconstruction to a CSV file.
-**Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
-**Reconstruction CSV:** Loading the source reconstruction from the output CSV file and performing analysis.
+- **Model Fit:** Running a pixelization model-fit which outputs the source reconstruction to a CSV file.
+- **Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
+- **Reconstruction CSV:** Loading the source reconstruction from the output CSV file and performing analysis.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/imaging/features/shapelets/fit.py
+++ b/scripts/imaging/features/shapelets/fit.py
@@ -19,19 +19,19 @@ feature).
 
 __Contents__
 
-**Advantages & Disadvantages:** Benefits and drawbacks of using shapelets.
-**Dataset & Mask:** Standard set up of imaging dataset that is fitted.
-**Basis:** How to create a basis of multiple light profiles, in this example shapelets.
-**Coefficients:** A visualization of the real and imaginary shapelet coefficients in the Basis.
-**Linear Light Profiles:** How to create a basis of linear light profiles to perform the shapelet decomposition.
-**Fit:** Perform a fit to a dataset using linear light profile MGE.
-**Intensities:** Access the solved for intensities of linear light profiles from the fit.
-**Model:** Composing a model using shapelets and how it changes the number of free parameters.
-**Search & Analysis:** Standard set up of non-linear search and analysis.
-**Run Time:** Profiling of shapelet run times and discussion of how they compare to standard light profiles.
-**Model-Fit:** Performs the model fit using standard API.
-**Result:** Shaeplet results, including accessing light profiles with solved for intensity values.
-**Cartesian Shapelets:** Using shapelets definedon a Cartesian coordinate system instead of polar coordinates.
+- **Advantages & Disadvantages:** Benefits and drawbacks of using shapelets.
+- **Dataset & Mask:** Standard set up of imaging dataset that is fitted.
+- **Basis:** How to create a basis of multiple light profiles, in this example shapelets.
+- **Coefficients:** A visualization of the real and imaginary shapelet coefficients in the Basis.
+- **Linear Light Profiles:** How to create a basis of linear light profiles to perform the shapelet decomposition.
+- **Fit:** Perform a fit to a dataset using linear light profile MGE.
+- **Intensities:** Access the solved for intensities of linear light profiles from the fit.
+- **Model:** Composing a model using shapelets and how it changes the number of free parameters.
+- **Search & Analysis:** Standard set up of non-linear search and analysis.
+- **Run Time:** Profiling of shapelet run times and discussion of how they compare to standard light profiles.
+- **Model-Fit:** Performs the model fit using standard API.
+- **Result:** Shaeplet results, including accessing light profiles with solved for intensity values.
+- **Cartesian Shapelets:** Using shapelets definedon a Cartesian coordinate system instead of polar coordinates.
 
 __Advantages__
 

--- a/scripts/imaging/features/shapelets/modeling.py
+++ b/scripts/imaging/features/shapelets/modeling.py
@@ -19,21 +19,21 @@ feature).
 
 __Contents__
 
-**Advantages & Disadvantages:** Benefits and drawbacks of using shapelets.
-**Dataset & Mask:** Standard set up of imaging dataset that is fitted.
-**Basis:** How to create a basis of multiple light profiles, in this example shapelets.
-**Coefficients:** A visualization of the real and imaginary shapelet coefficients in the Basis.
-**Linear Light Profiles:** How to create a basis of linear light profiles to perform the shapelet decomposition.
-**Fit:** Perform a fit to a dataset using linear light profile MGE.
-**Intensities:** Access the solved for intensities of linear light profiles from the fit.
-**Model:** Composing a model using shapelets and how it changes the number of free parameters.
-**Search & Analysis:** Standard set up of non-linear search and analysis.
-**Run Time:** Profiling of shapelet run times and discussion of how they compare to standard light profiles.
-**Model-Fit:** Performs the model fit using standard API.
-**Result:** Shaeplet results, including accessing light profiles with solved for intensity values.
-**Cartesian Shapelets:** Using shapelets definedon a Cartesian coordinate system instead of polar coordinates.
-**Lens Shapelets:** Using shapelets to decompose the lens galaxy instead of the source galaxy.
-**Regularization:** API for applying regularization to shapelets, which is not recommend but included for illustration.
+- **Advantages & Disadvantages:** Benefits and drawbacks of using shapelets.
+- **Dataset & Mask:** Standard set up of imaging dataset that is fitted.
+- **Basis:** How to create a basis of multiple light profiles, in this example shapelets.
+- **Coefficients:** A visualization of the real and imaginary shapelet coefficients in the Basis.
+- **Linear Light Profiles:** How to create a basis of linear light profiles to perform the shapelet decomposition.
+- **Fit:** Perform a fit to a dataset using linear light profile MGE.
+- **Intensities:** Access the solved for intensities of linear light profiles from the fit.
+- **Model:** Composing a model using shapelets and how it changes the number of free parameters.
+- **Search & Analysis:** Standard set up of non-linear search and analysis.
+- **Run Time:** Profiling of shapelet run times and discussion of how they compare to standard light profiles.
+- **Model-Fit:** Performs the model fit using standard API.
+- **Result:** Shaeplet results, including accessing light profiles with solved for intensity values.
+- **Cartesian Shapelets:** Using shapelets definedon a Cartesian coordinate system instead of polar coordinates.
+- **Lens Shapelets:** Using shapelets to decompose the lens galaxy instead of the source galaxy.
+- **Regularization:** API for applying regularization to shapelets, which is not recommend but included for illustration.
 
 __Advantages__
 

--- a/scripts/imaging/features/simulator_manual_signal_to_noise.py
+++ b/scripts/imaging/features/simulator_manual_signal_to_noise.py
@@ -36,12 +36,12 @@ If any code in this script is unclear, refer to the `simulators/start_here.ipynb
 
 __Contents__
 
-**Dataset Paths:** Defining the output path for the simulated dataset.
-**Grid:** Setting up the 2D grid with adaptive over-sampling for simulation.
-**Galaxies:** Defining two galaxies using signal-to-noise ratio based Sersic light profiles.
-**Output:** Saving the simulated dataset to FITS files.
-**Visualize:** Outputting subplot and image visualizations as PNG files.
-**Plane Output:** Saving the Galaxies object as a JSON file for future reference.
+- **Dataset Paths:** Defining the output path for the simulated dataset.
+- **Grid:** Setting up the 2D grid with adaptive over-sampling for simulation.
+- **Galaxies:** Defining two galaxies using signal-to-noise ratio based Sersic light profiles.
+- **Output:** Saving the simulated dataset to FITS files.
+- **Visualize:** Outputting subplot and image visualizations as PNG files.
+- **Plane Output:** Saving the Galaxies object as a JSON file for future reference.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/features/sky_background/fit.py
+++ b/scripts/imaging/features/sky_background/fit.py
@@ -32,12 +32,12 @@ If any code in this script is unclear, refer to the `fit` examples.
 
 __Contents__
 
-**Dataset:** Loading the sky background imaging dataset from FITS files.
-**Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
-**Mask:** Applying a circular mask to the dataset.
-**Over Sampling:** Applying adaptive over-sampling for accurate light profile evaluation.
-**Fit:** Performing a fit using a DatasetModel to include the sky background level.
-**Wrap Up:** Summary of sky background fitting with the DatasetModel object.
+- **Dataset:** Loading the sky background imaging dataset from FITS files.
+- **Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
+- **Mask:** Applying a circular mask to the dataset.
+- **Over Sampling:** Applying adaptive over-sampling for accurate light profile evaluation.
+- **Fit:** Performing a fit using a DatasetModel to include the sky background level.
+- **Wrap Up:** Summary of sky background fitting with the DatasetModel object.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/features/sky_background/modeling.py
+++ b/scripts/imaging/features/sky_background/modeling.py
@@ -32,18 +32,18 @@ If any code in this script is unclear, refer to the `modeling/start_here.ipynb` 
 
 __Contents__
 
-**Dataset:** Loading the sky background imaging dataset from FITS files.
-**Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
-**Mask:** Applying a circular mask to the dataset.
-**Over Sampling:** Applying adaptive over-sampling for accurate light profile evaluation.
-**Model:** Composing the galaxy model with a DatasetModel for the sky background.
-**Search:** Configuring the Nautilus nested sampling non-linear search.
-**Analysis:** Creating the AnalysisImaging object for likelihood evaluation.
-**VRAM:** Discussion of GPU VRAM usage with the sky background model.
-**Run Time:** Discussion of computational run times with the sky background model.
-**Model-Fit:** Running the model-fit and monitoring output.
-**Result:** Inspecting the result object and inferred sky background level.
-**Wrap Up:** Summary of sky background modeling with the DatasetModel object.
+- **Dataset:** Loading the sky background imaging dataset from FITS files.
+- **Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
+- **Mask:** Applying a circular mask to the dataset.
+- **Over Sampling:** Applying adaptive over-sampling for accurate light profile evaluation.
+- **Model:** Composing the galaxy model with a DatasetModel for the sky background.
+- **Search:** Configuring the Nautilus nested sampling non-linear search.
+- **Analysis:** Creating the AnalysisImaging object for likelihood evaluation.
+- **VRAM:** Discussion of GPU VRAM usage with the sky background model.
+- **Run Time:** Discussion of computational run times with the sky background model.
+- **Model-Fit:** Running the model-fit and monitoring output.
+- **Result:** Inspecting the result object and inferred sky background level.
+- **Wrap Up:** Summary of sky background modeling with the DatasetModel object.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/features/sky_background/simulator.py
+++ b/scripts/imaging/features/sky_background/simulator.py
@@ -21,12 +21,12 @@ If any code in this script is unclear, refer to the `simulators/start_here.ipynb
 
 __Contents__
 
-**Dataset Paths:** Defining the output path for the simulated dataset.
-**Grid:** Setting up the 2D grid with adaptive over-sampling for simulation.
-**Galaxies:** Defining the galaxy with a Sersic bulge light profile.
-**Output:** Saving the simulated dataset to FITS files.
-**Visualize:** Outputting subplot and image visualizations as PNG files.
-**Plane Output:** Saving the Galaxies object as a JSON file for future reference.
+- **Dataset Paths:** Defining the output path for the simulated dataset.
+- **Grid:** Setting up the 2D grid with adaptive over-sampling for simulation.
+- **Galaxies:** Defining the galaxy with a Sersic bulge light profile.
+- **Output:** Saving the simulated dataset to FITS files.
+- **Visualize:** Outputting subplot and image visualizations as PNG files.
+- **Plane Output:** Saving the Galaxies object as a JSON file for future reference.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/fit.py
+++ b/scripts/imaging/fit.py
@@ -34,21 +34,21 @@ and `modeling/features/pixelizaiton.py`.
 
 __Contents__
 
-**Loading Data:** Loading the imaging dataset from FITS files for fitting.
-**Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
-**Grid:** Setting up the over-sampled grid for light profile evaluation.
-**Mask:** Applying a circular mask to the dataset.
-**Fitting:** Creating galaxies from light profiles and fitting them to the data using FitImaging.
-**Bad Fit:** Demonstrating what a poor fit looks like with offset galaxy centres.
-**Fit Quantities:** Accessing model data, residuals and chi-squared arrays from the fit.
-**Figures of Merit:** Computing chi-squared, noise normalization and log likelihood scalar values.
-**Galaxy Quantities:** Extracting individual galaxy model images and subtracted images.
-**Unmasked Quantities:** Computing unmasked blurred images of the galaxies.
-**Mask:** Using a secondary mask to estimate fit quality in specific regions.
-**Pixel Counting:** Counting pixels with poor chi-squared values to quantify residual extent.
-**Outputting Results:** Saving fit quantities to FITS files for later analysis.
-**Modeling Results:** Links to modeling result analysis in the workspace.
-**Wrap Up:** Summary of the FitImaging object and next steps.
+- **Loading Data:** Loading the imaging dataset from FITS files for fitting.
+- **Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
+- **Grid:** Setting up the over-sampled grid for light profile evaluation.
+- **Mask:** Applying a circular mask to the dataset.
+- **Fitting:** Creating galaxies from light profiles and fitting them to the data using FitImaging.
+- **Bad Fit:** Demonstrating what a poor fit looks like with offset galaxy centres.
+- **Fit Quantities:** Accessing model data, residuals and chi-squared arrays from the fit.
+- **Figures of Merit:** Computing chi-squared, noise normalization and log likelihood scalar values.
+- **Galaxy Quantities:** Extracting individual galaxy model images and subtracted images.
+- **Unmasked Quantities:** Computing unmasked blurred images of the galaxies.
+- **Mask:** Using a secondary mask to estimate fit quality in specific regions.
+- **Pixel Counting:** Counting pixels with poor chi-squared values to quantify residual extent.
+- **Outputting Results:** Saving fit quantities to FITS files for later analysis.
+- **Modeling Results:** Links to modeling result analysis in the workspace.
+- **Wrap Up:** Summary of the FitImaging object and next steps.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/likelihood_function.py
+++ b/scripts/imaging/likelihood_function.py
@@ -16,22 +16,22 @@ packages are called when the likelihood is evaluated.
 
 __Contents__
 
-**Dataset:** Loading the imaging dataset for likelihood evaluation.
-**Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
-**Mask:** Defining and applying a circular mask to the data.
-**Over Sampling:** Disabling over-sampling for simplicity in this guide.
-**Masked Image Grid:** Setting up the 2D grid of masked image-pixel coordinates.
-**Light Profiles (Setup):** Defining Sersic bulge and Exponential disk light profiles for the galaxy model.
-**Galaxy:** Combining light profiles into a single Galaxy object.
-**Galaxy Image:** Computing the 2D image of the galaxy's combined light profiles.
-**Convolution:** Convolving the galaxy image with the PSF.
-**Likelihood Function:** Overview of the log likelihood function terms.
-**Chi Squared:** Computing the chi-squared statistic for the fit.
-**Noise Normalization Term:** Computing the noise normalization term of the likelihood.
-**Calculate The Log Likelihood:** Combining terms to compute the final log likelihood value.
-**Fit:** Performing the same likelihood evaluation using the FitImaging object.
-**Galaxy Modeling:** Brief description of how the likelihood is sampled by a non-linear search.
-**Wrap Up:** Summary and links to additional guides.
+- **Dataset:** Loading the imaging dataset for likelihood evaluation.
+- **Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
+- **Mask:** Defining and applying a circular mask to the data.
+- **Over Sampling:** Disabling over-sampling for simplicity in this guide.
+- **Masked Image Grid:** Setting up the 2D grid of masked image-pixel coordinates.
+- **Light Profiles (Setup):** Defining Sersic bulge and Exponential disk light profiles for the galaxy model.
+- **Galaxy:** Combining light profiles into a single Galaxy object.
+- **Galaxy Image:** Computing the 2D image of the galaxy's combined light profiles.
+- **Convolution:** Convolving the galaxy image with the PSF.
+- **Likelihood Function:** Overview of the log likelihood function terms.
+- **Chi Squared:** Computing the chi-squared statistic for the fit.
+- **Noise Normalization Term:** Computing the noise normalization term of the likelihood.
+- **Calculate The Log Likelihood:** Combining terms to compute the final log likelihood value.
+- **Fit:** Performing the same likelihood evaluation using the FitImaging object.
+- **Galaxy Modeling:** Brief description of how the likelihood is sampled by a non-linear search.
+- **Wrap Up:** Summary and links to additional guides.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/modeling.py
+++ b/scripts/imaging/modeling.py
@@ -36,21 +36,21 @@ described in the script `autogalaxy_workspace/*/data_preparation/imaging/start_h
 
 __Contents__
 
-**Dataset:** Loading the imaging dataset from FITS files.
-**Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
-**Mask:** Defining a 2D mask for the region of interest around the galaxy.
-**Over Sampling:** Applying adaptive over-sampling for accurate light profile evaluation.
-**Model:** Composing the galaxy model with linear Sersic bulge and Exponential disk.
-**Search:** Configuring the Nautilus nested sampling non-linear search.
-**Analysis:** Creating the AnalysisImaging object for likelihood evaluation.
-**VRAM Use:** Estimating GPU VRAM usage for JAX-accelerated fitting.
-**Run Times:** Discussion of computational run times and how to estimate them.
-**Model-Fit:** Running the model-fit and monitoring output.
-**Output Folder Layout:** Description of the structure of the `output` folder where results are written.
-**Result:** Inspecting the result object, maximum likelihood model and posteriors.
-**Features:** Links to advanced modeling features in the workspace.
-**Data Preparation:** Links to data preparation resources.
-**HowToGalaxy:** Links to the HowToGalaxy tutorial lectures.
+- **Dataset:** Loading the imaging dataset from FITS files.
+- **Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
+- **Mask:** Defining a 2D mask for the region of interest around the galaxy.
+- **Over Sampling:** Applying adaptive over-sampling for accurate light profile evaluation.
+- **Model:** Composing the galaxy model with linear Sersic bulge and Exponential disk.
+- **Search:** Configuring the Nautilus nested sampling non-linear search.
+- **Analysis:** Creating the AnalysisImaging object for likelihood evaluation.
+- **VRAM Use:** Estimating GPU VRAM usage for JAX-accelerated fitting.
+- **Run Times:** Discussion of computational run times and how to estimate them.
+- **Model-Fit:** Running the model-fit and monitoring output.
+- **Output Folder Layout:** Description of the structure of the `output` folder where results are written.
+- **Result:** Inspecting the result object, maximum likelihood model and posteriors.
+- **Features:** Links to advanced modeling features in the workspace.
+- **Data Preparation:** Links to data preparation resources.
+- **HowToGalaxy:** Links to the HowToGalaxy tutorial lectures.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/simulator.py
+++ b/scripts/imaging/simulator.py
@@ -9,13 +9,13 @@ This script simulates `Imaging` of a galaxy using light profiles where:
 
 __Contents__
 
-**Dataset Paths:** Defining the output path for the simulated dataset.
-**Grid:** Setting up the 2D grid of coordinates for image evaluation.
-**Over Sampling:** Applying adaptive over-sampling for accurate image simulation.
-**Galaxies:** Defining the galaxy with Sersic bulge and Exponential disk light profiles.
-**Output:** Saving the simulated dataset to FITS files.
-**Visualize:** Outputting subplot and image visualizations as PNG files.
-**Plane Output:** Saving the Galaxies object as a JSON file for future reference.
+- **Dataset Paths:** Defining the output path for the simulated dataset.
+- **Grid:** Setting up the 2D grid of coordinates for image evaluation.
+- **Over Sampling:** Applying adaptive over-sampling for accurate image simulation.
+- **Galaxies:** Defining the galaxy with Sersic bulge and Exponential disk light profiles.
+- **Output:** Saving the simulated dataset to FITS files.
+- **Visualize:** Outputting subplot and image visualizations as PNG files.
+- **Plane Output:** Saving the Galaxies object as a JSON file for future reference.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/simulator_sample.py
+++ b/scripts/imaging/simulator_sample.py
@@ -19,13 +19,13 @@ If any code in this script is unclear, refer to the `simulators/start_here.ipynb
 
 __Contents__
 
-**Dataset Paths:** Defining the output path for the simulated sample.
-**Grid:** Setting up the 2D grid with adaptive over-sampling for simulation.
-**Sample Model Distributions:** Defining prior distributions for the galaxy light profile parameters.
-**Sample Instances:** Generating random galaxy instances and simulating imaging datasets in a loop.
-**Output:** Saving each simulated dataset to FITS files.
-**Visualize:** Outputting subplot and image visualizations as PNG files.
-**Plane Output:** Saving each Galaxies object as a JSON file.
+- **Dataset Paths:** Defining the output path for the simulated sample.
+- **Grid:** Setting up the 2D grid with adaptive over-sampling for simulation.
+- **Sample Model Distributions:** Defining prior distributions for the galaxy light profile parameters.
+- **Sample Instances:** Generating random galaxy instances and simulating imaging datasets in a loop.
+- **Output:** Saving each simulated dataset to FITS files.
+- **Visualize:** Outputting subplot and image visualizations as PNG files.
+- **Plane Output:** Saving each Galaxies object as a JSON file.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/simulator_sersic.py
+++ b/scripts/imaging/simulator_sersic.py
@@ -8,13 +8,13 @@ This script simulates `Imaging` of a galaxy using light profiles where:
 
 __Contents__
 
-**Dataset Paths:** Set the output path for the simulated dataset.
-**Grid:** Create a 2D grid with adaptive over-sampling for simulation.
-**Galaxies:** Define the galaxy Sersic light profile used for simulation.
-**Output:** Save the simulated dataset to FITS files.
-**Visualize:** Output subplot and image PNGs of the simulated dataset.
-**Mask Extra Galaxies:** Save an empty `mask_extra_galaxies.fits` so noise-scaling tutorials can load it.
-**Plane Output:** Save the Galaxies object as a JSON file.
+- **Dataset Paths:** Set the output path for the simulated dataset.
+- **Grid:** Create a 2D grid with adaptive over-sampling for simulation.
+- **Galaxies:** Define the galaxy Sersic light profile used for simulation.
+- **Output:** Save the simulated dataset to FITS files.
+- **Visualize:** Output subplot and image PNGs of the simulated dataset.
+- **Mask Extra Galaxies:** Save an empty `mask_extra_galaxies.fits` so noise-scaling tutorials can load it.
+- **Plane Output:** Save the Galaxies object as a JSON file.
 
 __Start Here__
 

--- a/scripts/imaging/start_here.py
+++ b/scripts/imaging/start_here.py
@@ -25,20 +25,20 @@ or for investigating imaging effects in a controlled way.
 
 __Contents__
 
-**Google Colab Setup:** Setting up the environment for Google Colab, including installing dependencies.
-**Imports:** Importing autogalaxy, autofit and other required libraries.
-**Dataset:** Loading CCD imaging data (image, noise-map, PSF) from FITS files.
-**Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
-**Extra Galaxy Removal:** Masking and scaling noise for regions with extra galaxy emission.
-**Masking:** Defining a circular mask and applying adaptive over-sampling for the analysis.
-**Model:** Composing a Multi Gaussian Expansion (MGE) galaxy model.
-**Model Fit:** Fitting the model to the data using the Nautilus non-linear search.
-**Result:** Inspecting the model-fit results and best-fit model.
-**Extra Galaxy Removal GUI:** Interactive GUI tool for creating extra galaxy masks on your own data.
-**Model Your Own Galaxy:** Guidance on adapting the workflow for your own imaging data.
-**Simulator:** Simulating galaxy imaging data with a 2D grid and light profiles.
-**Sample:** Simulating many galaxies drawn from a model distribution for population studies.
-**Wrap Up:** Summary and links to further resources in the workspace.
+- **Google Colab Setup:** Setting up the environment for Google Colab, including installing dependencies.
+- **Imports:** Importing autogalaxy, autofit and other required libraries.
+- **Dataset:** Loading CCD imaging data (image, noise-map, PSF) from FITS files.
+- **Dataset Auto-Simulation:** Automatically simulating the dataset if it does not already exist.
+- **Extra Galaxy Removal:** Masking and scaling noise for regions with extra galaxy emission.
+- **Masking:** Defining a circular mask and applying adaptive over-sampling for the analysis.
+- **Model:** Composing a Multi Gaussian Expansion (MGE) galaxy model.
+- **Model Fit:** Fitting the model to the data using the Nautilus non-linear search.
+- **Result:** Inspecting the model-fit results and best-fit model.
+- **Extra Galaxy Removal GUI:** Interactive GUI tool for creating extra galaxy masks on your own data.
+- **Model Your Own Galaxy:** Guidance on adapting the workflow for your own imaging data.
+- **Simulator:** Simulating galaxy imaging data with a 2D grid and light profiles.
+- **Sample:** Simulating many galaxies drawn from a model distribution for population studies.
+- **Wrap Up:** Summary and links to further resources in the workspace.
 
 __Google Colab Setup__
 

--- a/scripts/interferometer/data_preparation.py
+++ b/scripts/interferometer/data_preparation.py
@@ -8,17 +8,17 @@ which will help you prepare your dataset to adhere to them if it does not alread
 
 __Contents__
 
-**SLACK:** Contact information for help with interferometer data preparation.
-**Pixel Scale:** Choosing the correct pixel scale for interferometer datasets.
-**Visibilities:** Loading and inspecting visibility data from FITS files.
-**Noise-Map:** Loading and inspecting the noise map for the interferometer dataset.
-**UV Wavelengths:** Loading and inspecting the uv-wavelength baselines.
-**Real Space Mask:** Setting up the real-space mask for Fourier transform evaluation.
-**Data Processing Complete:** Summary of required data standards and overview of optional steps.
-**Light Centre (Optional):** Marking the galaxy light centre to fix or constrain model parameters.
-**Extra Galaxies (Optional):** Marking centres of nearby extra galaxies for inclusion in the model.
-**Mask Extra Galaxies (Optional):** Creating masks to remove signal from nearby extra galaxies.
-**Info (Optional):** Storing auxiliary information like redshifts as a JSON file.
+- **SLACK:** Contact information for help with interferometer data preparation.
+- **Pixel Scale:** Choosing the correct pixel scale for interferometer datasets.
+- **Visibilities:** Loading and inspecting visibility data from FITS files.
+- **Noise-Map:** Loading and inspecting the noise map for the interferometer dataset.
+- **UV Wavelengths:** Loading and inspecting the uv-wavelength baselines.
+- **Real Space Mask:** Setting up the real-space mask for Fourier transform evaluation.
+- **Data Processing Complete:** Summary of required data standards and overview of optional steps.
+- **Light Centre (Optional):** Marking the galaxy light centre to fix or constrain model parameters.
+- **Extra Galaxies (Optional):** Marking centres of nearby extra galaxies for inclusion in the model.
+- **Mask Extra Galaxies (Optional):** Creating masks to remove signal from nearby extra galaxies.
+- **Info (Optional):** Storing auxiliary information like redshifts as a JSON file.
 
 __SLACK__
 

--- a/scripts/interferometer/features/pixelization/fit.py
+++ b/scripts/interferometer/features/pixelization/fit.py
@@ -39,27 +39,27 @@ CPU run times are also fast using the sparse operator formalism.
 
 __Contents__
 
-**Advantages:** Benefits of using pixelizations to model galaxy light.
-**Disadvantages:** Drawbacks and additional complexity of pixelized galaxy modeling.
-**Positive Only Solver:** How a positive solution to pixel fluxes is ensured, and why it is often disabled for interferometer data.
-**Mask:** Defining the real-space mask for the interferometer grid.
-**Dataset:** Loading the interferometer dataset from FITS files.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Sparse Operators:** Computing the sparse NUFFT operator matrix for fast linear algebra.
-**Settings:** Disabling the positive-only solver for interferometer data.
-**Over Sampling:** Why over sampling is not needed for interferometer data.
-**Mesh Shape:** Defining the number of pixels used by the rectangular mesh.
-**Pixelization:** Creating the pixelization with a mesh and regularization scheme.
-**Fit:** Performing a fit to a dataset using a pixelization and visualizing results.
-**Wrap Up:** Summary of when pixelizations are most useful.
-**Linear Objects:** Inspecting the linear objects used in the inversion.
-**Grids:** Accessing image-plane and reconstruction-plane grids from the mapper.
-**Reconstruction:** Accessing the reconstructed pixel values as a 1D array.
-**Mapped Reconstructed Images:** Accessing the reconstruction mapped back to the image plane.
-**Linear Algebra Matrices (Advanced):** Accessing the curvature, regularization and combined matrices.
-**Evidence Terms (Advanced):** Accessing individual Bayesian evidence terms from the inversion.
-**Simulated Interferometer:** Simulating an interferometer dataset from the pixelized reconstruction.
-**Future Ideas / Contributions:** Potential future additions to this tutorial.
+- **Advantages:** Benefits of using pixelizations to model galaxy light.
+- **Disadvantages:** Drawbacks and additional complexity of pixelized galaxy modeling.
+- **Positive Only Solver:** How a positive solution to pixel fluxes is ensured, and why it is often disabled for interferometer data.
+- **Mask:** Defining the real-space mask for the interferometer grid.
+- **Dataset:** Loading the interferometer dataset from FITS files.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Sparse Operators:** Computing the sparse NUFFT operator matrix for fast linear algebra.
+- **Settings:** Disabling the positive-only solver for interferometer data.
+- **Over Sampling:** Why over sampling is not needed for interferometer data.
+- **Mesh Shape:** Defining the number of pixels used by the rectangular mesh.
+- **Pixelization:** Creating the pixelization with a mesh and regularization scheme.
+- **Fit:** Performing a fit to a dataset using a pixelization and visualizing results.
+- **Wrap Up:** Summary of when pixelizations are most useful.
+- **Linear Objects:** Inspecting the linear objects used in the inversion.
+- **Grids:** Accessing image-plane and reconstruction-plane grids from the mapper.
+- **Reconstruction:** Accessing the reconstructed pixel values as a 1D array.
+- **Mapped Reconstructed Images:** Accessing the reconstruction mapped back to the image plane.
+- **Linear Algebra Matrices (Advanced):** Accessing the curvature, regularization and combined matrices.
+- **Evidence Terms (Advanced):** Accessing individual Bayesian evidence terms from the inversion.
+- **Simulated Interferometer:** Simulating an interferometer dataset from the pixelized reconstruction.
+- **Future Ideas / Contributions:** Potential future additions to this tutorial.
 
 __Advantages__
 

--- a/scripts/interferometer/features/pixelization/likelihood_function.py
+++ b/scripts/interferometer/features/pixelization/likelihood_function.py
@@ -27,37 +27,37 @@ learn about the linear light profile likelihood function without reading other l
 
 __Contents__
 
-**Mesh Shape:** Fixing the rectangular mesh shape before modeling.
-**Mask:** Defining the real-space mask for the interferometer grid.
-**Dataset:** Loading the interferometer dataset from FITS files.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Over Sampling:** Why over sampling is not needed for interferometer data.
-**Masked Image Grid:** Setting up the 2D coordinate grid for pixelization evaluation.
-**Galaxy:** Combining the pixelization into a Galaxy object.
-**Rectangular Mesh:** Creating the rectangular mesh overlaid on the masked image grid.
-**Interpolation:** Creating an interpolator describing how image pixels map to mesh pixels.
-**Mapper:** Creating the Mapper object that describes image-to-source pixel mappings.
-**Over Sampling:** How over sampling interacts with the pixelization mapping scheme.
-**Alternative Meshes:** Brief overview of other mesh types available.
-**Mapping Matrix:** Constructing the 2D mapping matrix from image pixels to source pixels.
-**Transformed Mapping Matrix ($f$):** Fourier transforming the mapping matrix to the uv-plane.
-**Data Vector (D):** Computing the data vector for the linear inversion.
-**Curvature Matrix (F):** Computing the curvature matrix for the linear inversion.
-**Regularization Matrix (H):** Constructing the regularization matrix to enforce smoothness.
-**F + Lamdba H:** Combining the curvature and regularization matrices.
-**Galaxy Reconstruction (s):** Solving the linear system to reconstruct the galaxy.
-**Visibilities Reconstruction:** Mapping the reconstruction back to the uv-plane.
-**Likelihood Function:** Defining the full Bayesian log likelihood for pixelized modeling.
-**Chi Squared:** Computing the chi-squared statistic from residuals and noise.
-**Regularization Term:** The regularization penalty term in the log likelihood.
-**Complexity Terms:** The log determinant terms that penalize overly complex reconstructions.
-**Noise Normalization Term:** The noise normalization constant in the log likelihood.
-**Calculate The Log Likelihood:** Combining all terms to compute the final log evidence.
-**Fit:** Performing the likelihood evaluation using the FitInterferometer object.
-**Galaxy Modeling:** Overview of how the likelihood function is sampled by a non-linear search.
-**Log Likelihood Function: Pixelization With Light Profile:** How the likelihood changes when parametric light profiles are included.
-**Log Likelihood Function: Fast Chi Squared:** Computing chi-squared without NUFFT for speed.
-**Wrap Up:** Summary and pointers to additional resources.
+- **Mesh Shape:** Fixing the rectangular mesh shape before modeling.
+- **Mask:** Defining the real-space mask for the interferometer grid.
+- **Dataset:** Loading the interferometer dataset from FITS files.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Over Sampling:** Why over sampling is not needed for interferometer data.
+- **Masked Image Grid:** Setting up the 2D coordinate grid for pixelization evaluation.
+- **Galaxy:** Combining the pixelization into a Galaxy object.
+- **Rectangular Mesh:** Creating the rectangular mesh overlaid on the masked image grid.
+- **Interpolation:** Creating an interpolator describing how image pixels map to mesh pixels.
+- **Mapper:** Creating the Mapper object that describes image-to-source pixel mappings.
+- **Over Sampling:** How over sampling interacts with the pixelization mapping scheme.
+- **Alternative Meshes:** Brief overview of other mesh types available.
+- **Mapping Matrix:** Constructing the 2D mapping matrix from image pixels to source pixels.
+- **Transformed Mapping Matrix ($f$):** Fourier transforming the mapping matrix to the uv-plane.
+- **Data Vector (D):** Computing the data vector for the linear inversion.
+- **Curvature Matrix (F):** Computing the curvature matrix for the linear inversion.
+- **Regularization Matrix (H):** Constructing the regularization matrix to enforce smoothness.
+- **F + Lamdba H:** Combining the curvature and regularization matrices.
+- **Galaxy Reconstruction (s):** Solving the linear system to reconstruct the galaxy.
+- **Visibilities Reconstruction:** Mapping the reconstruction back to the uv-plane.
+- **Likelihood Function:** Defining the full Bayesian log likelihood for pixelized modeling.
+- **Chi Squared:** Computing the chi-squared statistic from residuals and noise.
+- **Regularization Term:** The regularization penalty term in the log likelihood.
+- **Complexity Terms:** The log determinant terms that penalize overly complex reconstructions.
+- **Noise Normalization Term:** The noise normalization constant in the log likelihood.
+- **Calculate The Log Likelihood:** Combining all terms to compute the final log evidence.
+- **Fit:** Performing the likelihood evaluation using the FitInterferometer object.
+- **Galaxy Modeling:** Overview of how the likelihood function is sampled by a non-linear search.
+- **Log Likelihood Function: Pixelization With Light Profile:** How the likelihood changes when parametric light profiles are included.
+- **Log Likelihood Function: Fast Chi Squared:** Computing chi-squared without NUFFT for speed.
+- **Wrap Up:** Summary and pointers to additional resources.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/interferometer/features/pixelization/many_visibilities_preparation.py
+++ b/scripts/interferometer/features/pixelization/many_visibilities_preparation.py
@@ -32,12 +32,12 @@ and computes it from scratch if not.
 
 __Contents__
 
-**High Resolution Dataset:** Information on downloading high-resolution ALMA uv-wavelength data.
-**Dataset + Masking:** Loading the interferometer dataset and defining the real-space mask.
-**Profiling Dataset:** Profiling run times for different dataset sizes to plan computation.
-**Curvature Preload:** Computing the sparse NUFFT operator matrix for fast pixelized modeling.
-**Curvature Preload Output:** Saving and loading the precomputed matrix to and from hard-disk.
-**Wrap Up:** Summary of the preparation workflow for many-visibility datasets.
+- **High Resolution Dataset:** Information on downloading high-resolution ALMA uv-wavelength data.
+- **Dataset + Masking:** Loading the interferometer dataset and defining the real-space mask.
+- **Profiling Dataset:** Profiling run times for different dataset sizes to plan computation.
+- **Curvature Preload:** Computing the sparse NUFFT operator matrix for fast pixelized modeling.
+- **Curvature Preload Output:** Saving and loading the precomputed matrix to and from hard-disk.
+- **Wrap Up:** Summary of the preparation workflow for many-visibility datasets.
 
 __High Resolution Dataset__
 

--- a/scripts/interferometer/features/pixelization/modeling.py
+++ b/scripts/interferometer/features/pixelization/modeling.py
@@ -34,28 +34,28 @@ performed before galaxy modeling and saved to hard disk for fast loading before 
 
 __Contents__
 
-**Advantages:** Benefits of using pixelizations to model galaxy light.
-**Disadvantages:** Drawbacks and additional complexity of pixelized galaxy modeling.
-**Positive Only Solver:** How a positive solution to pixel fluxes is ensured, and why it is often disabled for interferometer data.
-**Model:** Description of the pixelized galaxy model fitted in this example.
-**Mask:** Defining the real-space mask for the interferometer grid.
-**Dataset:** Loading the interferometer dataset from FITS files.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Sparse Operators:** Computing the sparse NUFFT operator matrix for fast linear algebra.
-**Settings:** Disabling the positive-only solver for interferometer data.
-**Over Sampling:** Why over sampling is not needed for interferometer data.
-**Mesh Shape:** Defining the number of pixels used by the rectangular mesh.
-**Model:** Composing a pixelized galaxy model with a mesh and regularization scheme.
-**Search:** Configuring the Nautilus nested sampling non-linear search.
-**Analysis:** Setting up the AnalysisInterferometer object with JAX acceleration.
-**VRAM:** Estimating GPU VRAM requirements for pixelized modeling.
-**Run Time:** Profiling run times for pixelized modeling and how they scale.
-**Model-Fit:** Running the non-linear search to fit the model to data.
-**Result:** Inspecting the result object and maximum likelihood pixelized reconstruction.
-**Wrap Up:** Summary of when pixelizations are most useful.
-**Chaining:** Using non-linear search chaining to improve pixelized galaxy modeling.
-**HowToGalaxy:** Pointers to detailed pixelization tutorials in the lecture series.
-**Future Ideas / Contributions:** Potential future additions to this tutorial.
+- **Advantages:** Benefits of using pixelizations to model galaxy light.
+- **Disadvantages:** Drawbacks and additional complexity of pixelized galaxy modeling.
+- **Positive Only Solver:** How a positive solution to pixel fluxes is ensured, and why it is often disabled for interferometer data.
+- **Model:** Description of the pixelized galaxy model fitted in this example.
+- **Mask:** Defining the real-space mask for the interferometer grid.
+- **Dataset:** Loading the interferometer dataset from FITS files.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Sparse Operators:** Computing the sparse NUFFT operator matrix for fast linear algebra.
+- **Settings:** Disabling the positive-only solver for interferometer data.
+- **Over Sampling:** Why over sampling is not needed for interferometer data.
+- **Mesh Shape:** Defining the number of pixels used by the rectangular mesh.
+- **Model:** Composing a pixelized galaxy model with a mesh and regularization scheme.
+- **Search:** Configuring the Nautilus nested sampling non-linear search.
+- **Analysis:** Setting up the AnalysisInterferometer object with JAX acceleration.
+- **VRAM:** Estimating GPU VRAM requirements for pixelized modeling.
+- **Run Time:** Profiling run times for pixelized modeling and how they scale.
+- **Model-Fit:** Running the non-linear search to fit the model to data.
+- **Result:** Inspecting the result object and maximum likelihood pixelized reconstruction.
+- **Wrap Up:** Summary of when pixelizations are most useful.
+- **Chaining:** Using non-linear search chaining to improve pixelized galaxy modeling.
+- **HowToGalaxy:** Pointers to detailed pixelization tutorials in the lecture series.
+- **Future Ideas / Contributions:** Potential future additions to this tutorial.
 
 __Advantages__
 

--- a/scripts/interferometer/features/pixelization/source_science.py
+++ b/scripts/interferometer/features/pixelization/source_science.py
@@ -13,9 +13,9 @@ easily loaded to perform analysis without the need for PyAutoGalaxy.
 
 __Contents__
 
-**Model Fit:** Performing a pixelized galaxy model fit to interferometer data.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Reconstruction CSV:** Loading and using the pixelization reconstruction from a CSV file.
+- **Model Fit:** Performing a pixelized galaxy model fit to interferometer data.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Reconstruction CSV:** Loading and using the pixelization reconstruction from a CSV file.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/interferometer/fit.py
+++ b/scripts/interferometer/fit.py
@@ -15,15 +15,15 @@ This example uses functionality described fully in other examples in the `guides
 
 __Contents__
 
-**Mask:** Defining the real-space mask for the interferometer grid.
-**Loading Data:** Loading the interferometer dataset from FITS files.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Fitting:** Creating a galaxy model and fitting it to the data using FitInterferometer.
-**Bad Fit:** Demonstrating how a poor galaxy model produces residuals.
-**Fit Quantities:** Inspecting model data, residual maps, and dirty image variants of the fit.
-**Figures of Merit:** Computing chi-squared, noise normalization, and log likelihood values.
-**Galaxy Quantities:** Accessing per-galaxy model visibilities and images from the fit.
-**Outputting Results:** Saving fit results to FITS files for later use.
+- **Mask:** Defining the real-space mask for the interferometer grid.
+- **Loading Data:** Loading the interferometer dataset from FITS files.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Fitting:** Creating a galaxy model and fitting it to the data using FitInterferometer.
+- **Bad Fit:** Demonstrating how a poor galaxy model produces residuals.
+- **Fit Quantities:** Inspecting model data, residual maps, and dirty image variants of the fit.
+- **Figures of Merit:** Computing chi-squared, noise normalization, and log likelihood values.
+- **Galaxy Quantities:** Accessing per-galaxy model visibilities and images from the fit.
+- **Outputting Results:** Saving fit results to FITS files for later use.
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/interferometer/likelihood_function.py
+++ b/scripts/interferometer/likelihood_function.py
@@ -16,22 +16,22 @@ packages are called when the likelihood is evaluated.
 
 __Contents__
 
-**Mask:** Defining the real-space mask for the interferometer grid.
-**Dataset:** Loading the interferometer dataset from FITS files.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Over Sampling:** Why over sampling is not needed for interferometer data.
-**Masked Image Grid:** Setting up the 2D coordinate grid for light profile evaluation.
-**Light Profiles (Setup):** Defining the Sersic and Exponential light profiles for the galaxy model.
-**Galaxy:** Combining light profiles into a Galaxy object.
-**Galaxy Image:** Computing the 2D image of the galaxy from its light profiles.
-**Fourier Transform:** Transforming the galaxy image to the uv-plane via NUFFT.
-**Likelihood Function:** Quantifying the goodness-of-fit of the galaxy model.
-**Chi Squared:** Computing the chi-squared statistic from residuals and noise.
-**Noise Normalization Term:** The noise normalization constant in the log likelihood.
-**Calculate The Log Likelihood:** Combining terms to compute the final log likelihood value.
-**Fit:** Performing the likelihood evaluation using the FitInterferometer object.
-**Galaxy Modeling:** Overview of how the likelihood function is sampled by a non-linear search.
-**Wrap Up:** Summary and pointers to additional resources.
+- **Mask:** Defining the real-space mask for the interferometer grid.
+- **Dataset:** Loading the interferometer dataset from FITS files.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Over Sampling:** Why over sampling is not needed for interferometer data.
+- **Masked Image Grid:** Setting up the 2D coordinate grid for light profile evaluation.
+- **Light Profiles (Setup):** Defining the Sersic and Exponential light profiles for the galaxy model.
+- **Galaxy:** Combining light profiles into a Galaxy object.
+- **Galaxy Image:** Computing the 2D image of the galaxy from its light profiles.
+- **Fourier Transform:** Transforming the galaxy image to the uv-plane via NUFFT.
+- **Likelihood Function:** Quantifying the goodness-of-fit of the galaxy model.
+- **Chi Squared:** Computing the chi-squared statistic from residuals and noise.
+- **Noise Normalization Term:** The noise normalization constant in the log likelihood.
+- **Calculate The Log Likelihood:** Combining terms to compute the final log likelihood value.
+- **Fit:** Performing the likelihood evaluation using the FitInterferometer object.
+- **Galaxy Modeling:** Overview of how the likelihood function is sampled by a non-linear search.
+- **Wrap Up:** Summary and pointers to additional resources.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/interferometer/modeling.py
+++ b/scripts/interferometer/modeling.py
@@ -26,24 +26,24 @@ being small enough to be modeled with light profiles, is around **10,000 visibil
 
 __Contents__
 
-**Number of Visibilities:** Discussion of dataset size and when to use pixelized source reconstructions.
-**Model:** Description of the galaxy model fitted in this example.
-**Mask:** Defining the real-space mask for the interferometer grid.
-**Dataset:** Loading the interferometer dataset from FITS files.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Over Sampling:** Why over sampling is not needed for interferometer data.
-**Model:** Composing a Sersic bulge and Exponential disk galaxy model using linear light profiles.
-**Search:** Configuring the Nautilus nested sampling non-linear search.
-**Analysis:** Setting up the AnalysisInterferometer object with JAX acceleration.
-**VRAM Use:** Estimating GPU VRAM requirements for the model fit.
-**Run Times:** Estimating the computational cost of the model fit.
-**Model-Fit:** Running the non-linear search to fit the model to data.
-**Output Folder Layout:** Description of the structure of the `output` folder where results are written.
-**Result:** Inspecting the result object and maximum likelihood model.
-**Features:** Overview of advanced interferometer modeling features like pixelizations.
-**Data Preparation:** Pointers to data preparation scripts for your own data.
-**HowToGalaxy:** Pointers to the HowToGalaxy lecture series for deeper understanding.
-**Modeling Customization:** Overview of alternative non-linear searches and model customization.
+- **Number of Visibilities:** Discussion of dataset size and when to use pixelized source reconstructions.
+- **Model:** Description of the galaxy model fitted in this example.
+- **Mask:** Defining the real-space mask for the interferometer grid.
+- **Dataset:** Loading the interferometer dataset from FITS files.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Over Sampling:** Why over sampling is not needed for interferometer data.
+- **Model:** Composing a Sersic bulge and Exponential disk galaxy model using linear light profiles.
+- **Search:** Configuring the Nautilus nested sampling non-linear search.
+- **Analysis:** Setting up the AnalysisInterferometer object with JAX acceleration.
+- **VRAM Use:** Estimating GPU VRAM requirements for the model fit.
+- **Run Times:** Estimating the computational cost of the model fit.
+- **Model-Fit:** Running the non-linear search to fit the model to data.
+- **Output Folder Layout:** Description of the structure of the `output` folder where results are written.
+- **Result:** Inspecting the result object and maximum likelihood model.
+- **Features:** Overview of advanced interferometer modeling features like pixelizations.
+- **Data Preparation:** Pointers to data preparation scripts for your own data.
+- **HowToGalaxy:** Pointers to the HowToGalaxy lecture series for deeper understanding.
+- **Modeling Customization:** Overview of alternative non-linear searches and model customization.
 
 __Model__
 

--- a/scripts/interferometer/simulator.py
+++ b/scripts/interferometer/simulator.py
@@ -8,11 +8,11 @@ This script simulates `Interferometer` data of a galaxy where:
 
 __Contents__
 
-**Grid:** Defining the 2D grid for evaluating galaxy images in real space.
-**Galaxies:** Setting up the galaxy with bulge and disk light profiles for simulation.
-**Output:** Saving the simulated dataset to FITS files.
-**Visualize:** Outputting subplot and image visualizations as PNG files.
-**Plane Output:** Saving the galaxy model as a JSON file for future reference.
+- **Grid:** Defining the 2D grid for evaluating galaxy images in real space.
+- **Galaxies:** Setting up the galaxy with bulge and disk light profiles for simulation.
+- **Output:** Saving the simulated dataset to FITS files.
+- **Visualize:** Outputting subplot and image visualizations as PNG files.
+- **Plane Output:** Saving the galaxy model as a JSON file for future reference.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/interferometer/start_here.py
+++ b/scripts/interferometer/start_here.py
@@ -44,20 +44,20 @@ being small enough to be modeled with light profiles, is around **10,000 visibil
 
 __Contents__
 
-**JAX:** Overview of JAX GPU/CPU acceleration for fast model fitting.
-**Number of Visibilities:** Discussion of dataset size and when to use pixelized reconstructions.
-**Google Colab Setup:** Setting up the environment for Google Colab.
-**Imports:** Standard imports used across workspace examples.
-**Mask (Real Space):** Defining the real-space mask for interferometer modeling.
-**Dataset:** Loading interferometer data from FITS files.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Model:** Composing a Multi Gaussian Expansion galaxy model.
-**Model Fit:** Fitting the model to data using Nautilus nested sampling.
-**Result:** Inspecting the results of the model fit.
-**Model Your Own Galaxy:** Tips for applying this workflow to your own interferometer data.
-**Simulator:** Simulating interferometer datasets of galaxies.
-**Sample:** Simulating many galaxies from a model distribution.
-**Wrap Up:** Summary and pointers to further resources.
+- **JAX:** Overview of JAX GPU/CPU acceleration for fast model fitting.
+- **Number of Visibilities:** Discussion of dataset size and when to use pixelized reconstructions.
+- **Google Colab Setup:** Setting up the environment for Google Colab.
+- **Imports:** Standard imports used across workspace examples.
+- **Mask (Real Space):** Defining the real-space mask for interferometer modeling.
+- **Dataset:** Loading interferometer data from FITS files.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Model:** Composing a Multi Gaussian Expansion galaxy model.
+- **Model Fit:** Fitting the model to data using Nautilus nested sampling.
+- **Result:** Inspecting the results of the model fit.
+- **Model Your Own Galaxy:** Tips for applying this workflow to your own interferometer data.
+- **Simulator:** Simulating interferometer datasets of galaxies.
+- **Sample:** Simulating many galaxies from a model distribution.
+- **Wrap Up:** Summary and pointers to further resources.
 
 __Google Colab Setup__
 

--- a/scripts/multi/features/dataset_offsets/modeling.py
+++ b/scripts/multi/features/dataset_offsets/modeling.py
@@ -46,19 +46,19 @@ Two images are fitted, corresponding to a greener ('g' band) and redder image (`
 
 __Contents__
 
-**Advantages:** Benefits of accounting for dataset offsets in multi-wavelength modeling.
-**Disadvantages:** Additional free parameters introduced by offset modeling.
-**Model:** Description of the galaxy model fitted in this example.
-**Colors:** Defining the multi-wavelength color bands.
-**Pixel Scales:** Setting per-wavelength pixel scales.
-**Dataset:** Loading and plotting each multi-wavelength dataset.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Mask:** Applying a circular mask to each dataset.
-**Analysis:** Creating analysis objects for each dataset with JAX acceleration.
-**Model:** Composing a Sersic bulge and Exponential disk model with a DatasetModel for offsets.
-**Search:** Configuring the Nautilus nested sampling non-linear search.
-**Model-Fit:** Running the non-linear search to fit the model to all datasets simultaneously.
-**Result:** Inspecting the per-wavelength results and inferred dataset offsets.
+- **Advantages:** Benefits of accounting for dataset offsets in multi-wavelength modeling.
+- **Disadvantages:** Additional free parameters introduced by offset modeling.
+- **Model:** Description of the galaxy model fitted in this example.
+- **Colors:** Defining the multi-wavelength color bands.
+- **Pixel Scales:** Setting per-wavelength pixel scales.
+- **Dataset:** Loading and plotting each multi-wavelength dataset.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Mask:** Applying a circular mask to each dataset.
+- **Analysis:** Creating analysis objects for each dataset with JAX acceleration.
+- **Model:** Composing a Sersic bulge and Exponential disk model with a DatasetModel for offsets.
+- **Search:** Configuring the Nautilus nested sampling non-linear search.
+- **Model-Fit:** Running the non-linear search to fit the model to all datasets simultaneously.
+- **Result:** Inspecting the per-wavelength results and inferred dataset offsets.
 
 __Start Here Notebook__
 

--- a/scripts/multi/features/dataset_offsets/simulator.py
+++ b/scripts/multi/features/dataset_offsets/simulator.py
@@ -30,14 +30,14 @@ certain parts of code are not documented to ensure the script is concise.
 
 __Contents__
 
-**Colors:** Defining the multi-wavelength color bands.
-**Dataset Paths:** Setting the output path for simulated data.
-**Simulate:** Creating grids with per-wavelength pixel scales and over-sampling.
-**Offset:** Applying a sub-pixel offset to the second grid to simulate telescope pointing differences.
-**Galaxies:** Setting up galaxy light profiles with wavelength-dependent intensities.
-**Output:** Saving the simulated datasets to FITS files.
-**Visualize:** Outputting subplot and image visualizations as PNG files.
-**Galaxies json:** Saving the galaxy models as JSON files for future reference.
+- **Colors:** Defining the multi-wavelength color bands.
+- **Dataset Paths:** Setting the output path for simulated data.
+- **Simulate:** Creating grids with per-wavelength pixel scales and over-sampling.
+- **Offset:** Applying a sub-pixel offset to the second grid to simulate telescope pointing differences.
+- **Galaxies:** Setting up galaxy light profiles with wavelength-dependent intensities.
+- **Output:** Saving the simulated datasets to FITS files.
+- **Visualize:** Outputting subplot and image visualizations as PNG files.
+- **Galaxies json:** Saving the galaxy models as JSON files for future reference.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/multi/features/imaging_and_interferometer/modeling.py
+++ b/scripts/multi/features/imaging_and_interferometer/modeling.py
@@ -8,16 +8,16 @@ This script fits an `Imaging` dataset of a galaxy with a model where:
 
 __Contents__
 
-**Benefits:** Advantages of combining imaging and interferometer datasets.
-**Interferometer Masking:** Defining the real-space mask for the interferometer data.
-**Interferometer Dataset:** Loading the interferometer dataset from FITS files.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Imaging Dataset:** Loading the imaging dataset from FITS files.
-**Imaging Masking:** Applying a circular mask to the imaging dataset.
-**Analysis:** Creating analysis objects for both imaging and interferometer data.
-**Search:** Configuring the Nautilus nested sampling non-linear search.
-**Model-Fit:** Running the non-linear search to fit both datasets simultaneously.
-**Result:** Inspecting the results of the combined imaging and interferometer fit.
+- **Benefits:** Advantages of combining imaging and interferometer datasets.
+- **Interferometer Masking:** Defining the real-space mask for the interferometer data.
+- **Interferometer Dataset:** Loading the interferometer dataset from FITS files.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Imaging Dataset:** Loading the imaging dataset from FITS files.
+- **Imaging Masking:** Applying a circular mask to the imaging dataset.
+- **Analysis:** Creating analysis objects for both imaging and interferometer data.
+- **Search:** Configuring the Nautilus nested sampling non-linear search.
+- **Model-Fit:** Running the non-linear search to fit both datasets simultaneously.
+- **Result:** Inspecting the results of the combined imaging and interferometer fit.
 
 __Benefits__
 

--- a/scripts/multi/features/imaging_and_interferometer/simulator.py
+++ b/scripts/multi/features/imaging_and_interferometer/simulator.py
@@ -13,11 +13,11 @@ It is used to demonstrate the combination of imaging and interferometer datasets
 
 __Contents__
 
-**Simulate:** Creating the grid and uv-wavelengths for interferometer simulation.
-**Galaxies:** Setting up the galaxy with bulge and disk light profiles.
-**Output:** Saving the simulated interferometer dataset to FITS files.
-**Visualize:** Outputting subplot and image visualizations as PNG files.
-**Galaxies json:** Saving the galaxy model as a JSON file for future reference.
+- **Simulate:** Creating the grid and uv-wavelengths for interferometer simulation.
+- **Galaxies:** Setting up the galaxy with bulge and disk light profiles.
+- **Output:** Saving the simulated interferometer dataset to FITS files.
+- **Visualize:** Outputting subplot and image visualizations as PNG files.
+- **Galaxies json:** Saving the galaxy model as a JSON file for future reference.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/multi/features/one_by_one/modeling.py
+++ b/scripts/multi/features/one_by_one/modeling.py
@@ -40,19 +40,19 @@ Two images are fitted, corresponding to a greener ('g' band) and redder image (`
 
 __Contents__
 
-**Model:** Description of the galaxy model fitted in this example.
-**Colors:** Defining the multi-wavelength color bands.
-**Pixel Scales:** Setting per-wavelength pixel scales.
-**Dataset:** Loading and plotting each multi-wavelength dataset.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Mask:** Applying a circular mask to each dataset.
-**Analysis:** Creating analysis objects for each dataset with JAX acceleration.
-**Model:** Composing a Sersic bulge and Exponential disk model with linear light profiles.
-**Search:** Configuring the Nautilus nested sampling non-linear search.
-**Model-Fit:** Fitting the first (highest quality) dataset.
-**Result:** Inspecting the result of the first dataset fit.
-**Second Dataset Bulge Model Fixed:** Fitting the second dataset with the bulge fixed from the first result.
-**Second Dataset Offset:** Fitting for the offset between datasets with all model parameters fixed.
+- **Model:** Description of the galaxy model fitted in this example.
+- **Colors:** Defining the multi-wavelength color bands.
+- **Pixel Scales:** Setting per-wavelength pixel scales.
+- **Dataset:** Loading and plotting each multi-wavelength dataset.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Mask:** Applying a circular mask to each dataset.
+- **Analysis:** Creating analysis objects for each dataset with JAX acceleration.
+- **Model:** Composing a Sersic bulge and Exponential disk model with linear light profiles.
+- **Search:** Configuring the Nautilus nested sampling non-linear search.
+- **Model-Fit:** Fitting the first (highest quality) dataset.
+- **Result:** Inspecting the result of the first dataset fit.
+- **Second Dataset Bulge Model Fixed:** Fitting the second dataset with the bulge fixed from the first result.
+- **Second Dataset Offset:** Fitting for the offset between datasets with all model parameters fixed.
 
 __Start Here Notebook__
 

--- a/scripts/multi/features/pixelization/modeling.py
+++ b/scripts/multi/features/pixelization/modeling.py
@@ -14,17 +14,17 @@ certain parts of code are not documented to ensure the script is concise.
 
 __Contents__
 
-**Colors:** Defining the multi-wavelength color bands.
-**Pixel Scales:** Setting per-wavelength pixel scales.
-**Dataset:** Loading and plotting each multi-wavelength dataset.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Mask:** Applying a circular mask to each dataset.
-**Mesh Shape:** Fixing the rectangular mesh shape before modeling.
-**Analysis:** Creating analysis objects for each dataset with JAX acceleration.
-**Model:** Composing a pixelized galaxy model with adaptive mesh and regularization.
-**Search:** Configuring the Nautilus nested sampling non-linear search.
-**Model-Fit:** Running the non-linear search to fit the model to all datasets simultaneously.
-**Result:** Inspecting the per-wavelength results of the pixelized model fit.
+- **Colors:** Defining the multi-wavelength color bands.
+- **Pixel Scales:** Setting per-wavelength pixel scales.
+- **Dataset:** Loading and plotting each multi-wavelength dataset.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Mask:** Applying a circular mask to each dataset.
+- **Mesh Shape:** Fixing the rectangular mesh shape before modeling.
+- **Analysis:** Creating analysis objects for each dataset with JAX acceleration.
+- **Model:** Composing a pixelized galaxy model with adaptive mesh and regularization.
+- **Search:** Configuring the Nautilus nested sampling non-linear search.
+- **Model-Fit:** Running the non-linear search to fit the model to all datasets simultaneously.
+- **Result:** Inspecting the per-wavelength results of the pixelized model fit.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/multi/features/same_wavelength/modeling.py
+++ b/scripts/multi/features/same_wavelength/modeling.py
@@ -21,15 +21,15 @@ certain parts of code are not documented to ensure the script is concise.
 
 __Contents__
 
-**Pixel Scales:** Setting pixel scales for same-wavelength datasets.
-**Dataset:** Loading and plotting each same-wavelength dataset.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Mask:** Applying a circular mask to each dataset.
-**Analysis:** Creating analysis objects for each dataset with JAX acceleration.
-**Model:** Composing a Sersic bulge and Exponential disk model with linear light profiles.
-**Search:** Configuring the Nautilus nested sampling non-linear search.
-**Model-Fit:** Running the non-linear search to fit the model to all datasets simultaneously.
-**Result:** Inspecting the per-dataset results of the model fit.
+- **Pixel Scales:** Setting pixel scales for same-wavelength datasets.
+- **Dataset:** Loading and plotting each same-wavelength dataset.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Mask:** Applying a circular mask to each dataset.
+- **Analysis:** Creating analysis objects for each dataset with JAX acceleration.
+- **Model:** Composing a Sersic bulge and Exponential disk model with linear light profiles.
+- **Search:** Configuring the Nautilus nested sampling non-linear search.
+- **Model-Fit:** Running the non-linear search to fit the model to all datasets simultaneously.
+- **Result:** Inspecting the per-dataset results of the model fit.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/multi/features/same_wavelength/simulator.py
+++ b/scripts/multi/features/same_wavelength/simulator.py
@@ -19,12 +19,12 @@ TODO: NEED TO INCLUDE DIFFERENT POINTING / CENTERINGS.
 
 __Contents__
 
-**Dataset Paths:** Setting the output path for simulated data.
-**Simulate:** Creating grids with matching pixel scales for same-wavelength observations.
-**Galaxies:** Setting up the galaxy with bulge and disk light profiles at one wavelength.
-**Output:** Saving the simulated datasets to FITS files.
-**Visualize:** Outputting subplot and image visualizations as PNG files.
-**Galaxies json:** Saving the galaxy model as a JSON file for future reference.
+- **Dataset Paths:** Setting the output path for simulated data.
+- **Simulate:** Creating grids with matching pixel scales for same-wavelength observations.
+- **Galaxies:** Setting up the galaxy with bulge and disk light profiles at one wavelength.
+- **Output:** Saving the simulated datasets to FITS files.
+- **Visualize:** Outputting subplot and image visualizations as PNG files.
+- **Galaxies json:** Saving the galaxy model as a JSON file for future reference.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/multi/features/wavelength_dependence/modeling.py
+++ b/scripts/multi/features/wavelength_dependence/modeling.py
@@ -24,18 +24,18 @@ If a free `effective radius` is created for every dataset, this would add 5+ fre
 
 __Contents__
 
-**Colors:** Defining the multi-wavelength color bands (g, r, I).
-**Wavelengths:** Defining the wavelength of each color band for parameterization.
-**Pixel Scales:** Setting per-wavelength pixel scales.
-**Dataset:** Loading and plotting each multi-wavelength dataset.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Mask:** Applying a circular mask to each dataset.
-**Analysis:** Creating analysis objects for each dataset with JAX acceleration.
-**Model:** Composing a Sersic bulge and Exponential disk model with linear light profiles.
-**Model + Analysis:** Parameterizing effective radius as a linear function of wavelength using prior arithmetic.
-**Search:** Configuring the Nautilus nested sampling non-linear search.
-**Model-Fit:** Running the non-linear search to fit the model to all datasets simultaneously.
-**Result:** Inspecting the per-wavelength results of the model fit.
+- **Colors:** Defining the multi-wavelength color bands (g, r, I).
+- **Wavelengths:** Defining the wavelength of each color band for parameterization.
+- **Pixel Scales:** Setting per-wavelength pixel scales.
+- **Dataset:** Loading and plotting each multi-wavelength dataset.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Mask:** Applying a circular mask to each dataset.
+- **Analysis:** Creating analysis objects for each dataset with JAX acceleration.
+- **Model:** Composing a Sersic bulge and Exponential disk model with linear light profiles.
+- **Model + Analysis:** Parameterizing effective radius as a linear function of wavelength using prior arithmetic.
+- **Search:** Configuring the Nautilus nested sampling non-linear search.
+- **Model-Fit:** Running the non-linear search to fit the model to all datasets simultaneously.
+- **Result:** Inspecting the per-wavelength results of the model fit.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/multi/features/wavelength_dependence/simulator.py
+++ b/scripts/multi/features/wavelength_dependence/simulator.py
@@ -20,15 +20,15 @@ certain parts of code are not documented to ensure the script is concise.
 
 __Contents__
 
-**Colors:** Defining the multi-wavelength color bands (g, r, I).
-**Wavelengths:** Defining the wavelength of each color band.
-**Dataset Paths:** Setting the output path for simulated data.
-**Simulate:** Creating grids with per-wavelength pixel scales and over-sampling.
-**Intensity vs Wavelength:** Defining linear relations for intensity as a function of wavelength.
-**Galaxies:** Setting up galaxy light profiles with wavelength-dependent intensities.
-**Output:** Saving the simulated datasets to FITS files.
-**Visualize:** Outputting subplot and image visualizations as PNG files.
-**Galaxies json:** Saving the galaxy models as JSON files for future reference.
+- **Colors:** Defining the multi-wavelength color bands (g, r, I).
+- **Wavelengths:** Defining the wavelength of each color band.
+- **Dataset Paths:** Setting the output path for simulated data.
+- **Simulate:** Creating grids with per-wavelength pixel scales and over-sampling.
+- **Intensity vs Wavelength:** Defining linear relations for intensity as a function of wavelength.
+- **Galaxies:** Setting up galaxy light profiles with wavelength-dependent intensities.
+- **Output:** Saving the simulated datasets to FITS files.
+- **Visualize:** Outputting subplot and image visualizations as PNG files.
+- **Galaxies json:** Saving the galaxy models as JSON files for future reference.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/multi/modeling.py
+++ b/scripts/multi/modeling.py
@@ -13,21 +13,21 @@ certain parts of code are not documented to ensure the script is concise.
 
 __Contents__
 
-**Colors:** Defining the multi-wavelength color bands.
-**Pixel Scales:** Setting per-wavelength pixel scales.
-**Dataset:** Loading and plotting each multi-wavelength dataset.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Mask:** Applying a circular mask to each dataset.
-**Over Sampling:** Applying adaptive over-sampling for accurate light profile evaluation.
-**Model:** Composing a Sersic bulge and Exponential disk model with linear light profiles.
-**Analysis List:** Creating analysis objects for each dataset with JAX acceleration.
-**Analysis Factor:** Wrapping each analysis in a factor graph with per-dataset model customization.
-**Factor Graph:** Combining all analysis factors into a global factor graph model.
-**Search:** Configuring the Nautilus nested sampling non-linear search.
-**VRAM Use:** Estimating GPU VRAM requirements for multi-dataset fitting.
-**Model-Fit:** Running the non-linear search to fit the model to all datasets simultaneously.
-**Result:** Inspecting the per-wavelength results of the multi-dataset model fit.
-**Wrap Up:** Summary and pointers to further resources.
+- **Colors:** Defining the multi-wavelength color bands.
+- **Pixel Scales:** Setting per-wavelength pixel scales.
+- **Dataset:** Loading and plotting each multi-wavelength dataset.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Mask:** Applying a circular mask to each dataset.
+- **Over Sampling:** Applying adaptive over-sampling for accurate light profile evaluation.
+- **Model:** Composing a Sersic bulge and Exponential disk model with linear light profiles.
+- **Analysis List:** Creating analysis objects for each dataset with JAX acceleration.
+- **Analysis Factor:** Wrapping each analysis in a factor graph with per-dataset model customization.
+- **Factor Graph:** Combining all analysis factors into a global factor graph model.
+- **Search:** Configuring the Nautilus nested sampling non-linear search.
+- **VRAM Use:** Estimating GPU VRAM requirements for multi-dataset fitting.
+- **Model-Fit:** Running the non-linear search to fit the model to all datasets simultaneously.
+- **Result:** Inspecting the per-wavelength results of the multi-dataset model fit.
+- **Wrap Up:** Summary and pointers to further resources.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/multi/plot.py
+++ b/scripts/multi/plot.py
@@ -13,11 +13,11 @@ To show multiple subplots for a given dataset and fit, simply call each function
 
 __Contents__
 
-**Imaging Dataset Subplot:** Plotting a subplot of the imaging dataset.
-**Fit Imaging Subplot:** Plotting a subplot of the fit to the imaging dataset.
-**Galaxies Subplot:** Plotting a subplot of the galaxy images.
-**Output:** Saving each subplot to disk as PNG files.
-**Wrap Up:** Summary of the function-based subplot plotting API.
+- **Imaging Dataset Subplot:** Plotting a subplot of the imaging dataset.
+- **Fit Imaging Subplot:** Plotting a subplot of the fit to the imaging dataset.
+- **Galaxies Subplot:** Plotting a subplot of the galaxy images.
+- **Output:** Saving each subplot to disk as PNG files.
+- **Wrap Up:** Summary of the function-based subplot plotting API.
 
 __Start Here Notebook__
 

--- a/scripts/multi/simulator.py
+++ b/scripts/multi/simulator.py
@@ -13,13 +13,13 @@ certain parts of code are not documented to ensure the script is concise.
 
 __Contents__
 
-**Colors:** Defining the multi-wavelength color bands.
-**Dataset Paths:** Setting the output path for simulated data.
-**Simulate:** Creating grids with per-wavelength pixel scales and over-sampling.
-**Galaxies:** Setting up galaxy light profiles with wavelength-dependent intensities.
-**Output:** Saving the simulated datasets to FITS files.
-**Visualize:** Outputting subplot and image visualizations as PNG files.
-**Galaxies json:** Saving the galaxy models as JSON files for future reference.
+- **Colors:** Defining the multi-wavelength color bands.
+- **Dataset Paths:** Setting the output path for simulated data.
+- **Simulate:** Creating grids with per-wavelength pixel scales and over-sampling.
+- **Galaxies:** Setting up galaxy light profiles with wavelength-dependent intensities.
+- **Output:** Saving the simulated datasets to FITS files.
+- **Visualize:** Outputting subplot and image visualizations as PNG files.
+- **Galaxies json:** Saving the galaxy models as JSON files for future reference.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/multi/start_here.py
+++ b/scripts/multi/start_here.py
@@ -32,19 +32,19 @@ or for investigating imaging effects in a controlled way.
 
 __Contents__
 
-**JAX:** Overview of JAX GPU/CPU acceleration for fast model fitting.
-**Google Colab Setup:** Setting up the environment for Google Colab.
-**Imports:** Standard imports used across workspace examples.
-**Dataset:** Loading multi-wavelength imaging data from FITS files.
-**Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
-**Masking:** Defining a circular mask and applying adaptive over-sampling.
-**Model:** Composing a Multi Gaussian Expansion galaxy model for multi-wavelength data.
-**Analysis:** Creating analysis objects for each wavelength dataset with JAX acceleration.
-**Model Fit:** Fitting the model to data using Nautilus nested sampling with a factor graph.
-**Result:** Inspecting the results of the multi-wavelength model fit.
-**Model Your Own Galaxy:** Tips for applying this workflow to your own multi-wavelength data.
-**Simulator:** Pointers to the multi-wavelength simulation API.
-**Wrap Up:** Summary and pointers to further resources.
+- **JAX:** Overview of JAX GPU/CPU acceleration for fast model fitting.
+- **Google Colab Setup:** Setting up the environment for Google Colab.
+- **Imports:** Standard imports used across workspace examples.
+- **Dataset:** Loading multi-wavelength imaging data from FITS files.
+- **Dataset Auto-Simulation:** Automatically simulating data if it does not exist.
+- **Masking:** Defining a circular mask and applying adaptive over-sampling.
+- **Model:** Composing a Multi Gaussian Expansion galaxy model for multi-wavelength data.
+- **Analysis:** Creating analysis objects for each wavelength dataset with JAX acceleration.
+- **Model Fit:** Fitting the model to data using Nautilus nested sampling with a factor graph.
+- **Result:** Inspecting the results of the multi-wavelength model fit.
+- **Model Your Own Galaxy:** Tips for applying this workflow to your own multi-wavelength data.
+- **Simulator:** Pointers to the multi-wavelength simulation API.
+- **Wrap Up:** Summary and pointers to further resources.
 
 __Google Colab Setup__
 


### PR DESCRIPTION
## Summary

Convert `__Contents__` blocks at the top of every workspace tutorial script's module docstring from plain `**Section:**` lines into Markdown list bullets (`- **Section:**`).

Without bullet markers, GitHub and JupyterLab collapse the entire block into one continuous paragraph in the generated notebook's first markdown cell — exactly the opposite of what the index is meant to do. The fix is purely Markdown: prefixing each entry with `- ` makes it render as a list. No Python semantics change, no notebook execution change, no `.py`-script behaviour change.

A worked example shipped earlier on `ic50_workspace` (commit [`4cde480`](https://github.com/Jammy2211/ic50_workspace/commit/4cde480)).

## Scripts Changed

98 scripts under `scripts/`, covering: `ellipse`, `guides`, `imaging`, `interferometer`, `multi`. (3 files in this repo were already bulleted and were not touched.)

All edits are confined to the top-level module docstring — the `__Contents__` block.

## Test Plan
- [ ] Smoke tests pass

Refs PyAutoLabs/autolens_workspace#138

🤖 Generated with [Claude Code](https://claude.com/claude-code)