### PR TITLE
docs: refresh interferometer package for nufftax JAX-native NUFFT

### DIFF
--- a/scripts/interferometer/fit.py
+++ b/scripts/interferometer/fit.py
@@ -55,12 +55,11 @@ We we begin by loading the dataset `simple` from .fits files, which is the datas
 we will use to demonstrate fitting.
 
 This includes the method used to Fourier transform the real-space image to the uv-plane and compare
-directly to the visiblities. We use a non-uniform fast Fourier transform, which is the most efficient method for
-interferometer datasets containing ~1-10 million visibilities.
+directly to the visibilities. We use `TransformerNUFFT`, the JAX-native Non-Uniform Fast Fourier Transform
+backed by `nufftax`, which scales efficiently from a few hundred visibilities to tens of millions.
 
-This dataset was simulated using the `interferometer/simulator` example, read through that to have a better
-understanding of how the data this exam fits was generated. The simulation uses the `TransformerDFT` to map
-the real-space image to the uv-plane.
+This dataset was simulated using the `interferometer/simulator` example, read through that to understand how
+the data this example fits was generated.
 """
 dataset_name = "simple"
 dataset_path = Path("dataset") / "interferometer" / dataset_name
@@ -86,7 +85,7 @@ dataset = ag.Interferometer.from_fits(
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
-    transformer_class=ag.TransformerDFT,
+    transformer_class=ag.TransformerNUFFT,
 )
 
 """

--- a/scripts/interferometer/likelihood_function.py
+++ b/scripts/interferometer/likelihood_function.py
@@ -87,7 +87,7 @@ dataset = ag.Interferometer.from_fits(
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
-    transformer_class=ag.TransformerDFT,
+    transformer_class=ag.TransformerNUFFT,
 )
 
 """

--- a/scripts/interferometer/modeling.py
+++ b/scripts/interferometer/modeling.py
@@ -2,27 +2,24 @@
 Modeling: Start Here
 ====================
 
-This script is the starting point for modeling of interferometer datasets with less than 1000
-visibilities (e.g. SMA, ALMA) and it provides an overview of the modeling API.
+This script is the starting point for modeling of interferometer datasets (e.g. SMA, ALMA) and it provides an
+overview of the modeling API. The same workflow scales from a few hundred visibilities to many millions,
+thanks to the JAX-native `TransformerNUFFT` (backed by `nufftax`).
 
 __Number of Visibilities__
 
 This example fits a **low-resolution interferometric dataset** with a small number of visibilities (273). The
-dataset is intentionally minimal so that the example runs quickly and allows you to become familiar with the API
-and modeling workflow. The code demonstrated in this example can feasible fit datasets with up to around 10000
-visibilities, above which computational time and VRAM use become significant for this modeling approach.
+dataset is intentionally minimal so the example runs quickly and you can become familiar with the API and
+modeling workflow.
 
-High-resolution datasets with many visibilities (e.g. high-quality ALMA observations
-with **millions hundreds of millions of visibilities**) can be modeled efficiently. However, this requires
-using the more advanced **pixelized source reconstructions** modeling approach. These large datasets fully
-exploit **JAX acceleration**, enable modeling to run in **hours on a modern GPU**.
+The same workflow — light profiles + `TransformerNUFFT` (backed by `nufftax`, https://github.com/GragasLab/nufftax) —
+scales to high-resolution datasets with **millions to hundreds of millions of visibilities** (e.g. ALMA), with no
+change beyond the transformer choice. The NUFFT runs inside JAX's jit/vmap pipeline, so both run time and VRAM
+stay manageable on a GPU at any visibility count.
 
-If your dataset contains many visibilities, you should start by working through this example and the other examples
-in the `interferometer` folder. Once you are comfortable with the API, the `feature/pixelization` package provides a
-guided path toward efficiently modeling large interferometric datasets.
-
-The threshold between a dataset having many visibilities and therefore requiring pixelized source reconstructions, or
-being small enough to be modeled with light profiles, is around **10,000 visibilities**.
+Pixelized reconstructions (see `features/pixelization`) remain the right tool when the galaxy has complex,
+irregular morphology that simple light profiles cannot capture. They are no longer required purely because
+the dataset is large.
 
 __Contents__
 
@@ -107,7 +104,7 @@ dataset = ag.Interferometer.from_fits(
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
-    transformer_class=ag.TransformerDFT,
+    transformer_class=ag.TransformerNUFFT,
 )
 
 aplt.subplot_interferometer_dirty_images(dataset=dataset)
@@ -368,8 +365,8 @@ __Features__
 The examples in the `autogalaxy_workspace/*/interferometer/features` package illustrate other galaxy modeling
 features.
 
-We recommend you check out just one feature next, because it makes galaxy modeling of interferometer datasets
-more reliable and efficient, and will then allow you to model high-resolution datasets with many visibilities:
+We recommend you check out the `pixelization` feature next, which lets you reconstruct galaxies with complex,
+irregular morphology that simple light profiles cannot capture:
 
 - ``pixelization``: The galaxy’s light is reconstructed using an adaptive Rectangular mesh or Delaunay mesh.
 

--- a/scripts/interferometer/simulator.py
+++ b/scripts/interferometer/simulator.py
@@ -74,14 +74,18 @@ uv_wavelengths = ag.ndarray_via_fits_from(
 )
 
 """
-To simulate the interferometer dataset we first create a simulator, which defines the exposure time, noise levels 
+To simulate the interferometer dataset we first create a simulator, which defines the exposure time, noise levels
 and Fourier transform method used in the simulation.
+
+We use `TransformerNUFFT` (backed by `nufftax`, https://github.com/GragasLab/nufftax), a JAX-native Non-Uniform
+Fast Fourier Transform. This is the recommended transformer at any visibility count and is fast enough to
+simulate ALMA-class datasets with millions of visibilities end-to-end on a GPU.
 """
 simulator = ag.SimulatorInterferometer(
     uv_wavelengths=uv_wavelengths,
     exposure_time=300.0,
     noise_sigma=1000.0,
-    transformer_class=ag.TransformerDFT,
+    transformer_class=ag.TransformerNUFFT,
 )
 
 """

--- a/scripts/interferometer/start_here.py
+++ b/scripts/interferometer/start_here.py
@@ -23,29 +23,44 @@ If you don’t have a GPU locally, consider Google Colab which provides free GPU
 We also show how to simulate interferometer datasets. This is useful for building machine
 learning training datasets, or for investigating galaxy structure in a controlled way.
 
+__NUFFT (nufftax)__
+
+The image-to-visibilities Fourier transform is performed by a Non-Uniform Fast Fourier Transform (NUFFT),
+exposed in **PyAutoGalaxy** as `TransformerNUFFT`. The default backend is `nufftax`, a pure-JAX NUFFT
+that jit-compiles and vmap-batches like the rest of the library:
+
+  https://github.com/GragasLab/nufftax
+
+Because `nufftax` is JAX-native, light-profile interferometer modeling now runs at full GPU speed for
+datasets with **arbitrarily many visibilities** — including high-resolution ALMA observations with tens of
+millions to hundreds of millions of visibilities. Previously this was only practical for small datasets,
+or required switching to a pixelized reconstruction. Pixelized reconstructions are still recommended for
+complex, irregular galaxy morphologies (see `features/pixelization`), but they are no longer a
+performance requirement for large datasets.
+
+If `nufftax` is not installed, install it via `pip install nufftax`. A legacy pynufft-backed
+transformer (`TransformerNUFFTPyNUFFT`) is also available as a non-JAX fallback.
+
 __Number of Visibilities__
 
 This example fits a **low-resolution interferometric dataset** with a small number of visibilities (273). The
 dataset is intentionally minimal so that the example runs quickly and allows you to become familiar with the API
-and modeling workflow. The code demonstrated in this example can feasible fit datasets with up to around 10000
-visibilities, above which computational time and VRAM use become significant for this modeling approach.
+and modeling workflow.
 
-High-resolution datasets with many visibilities (e.g. high-quality ALMA observations
-with **millions hundreds of millions of visibilities**) can be modeled efficiently. However, this requires
-using the more advanced **pixelized reconstructions** modeling approach. These large datasets fully
-exploit **JAX acceleration**, enabling modeling to run in **hours on a modern GPU**.
+The same modeling workflow — light profiles + `TransformerNUFFT` (nufftax) — scales to high-resolution
+datasets with **millions to hundreds of millions of visibilities** (e.g. ALMA), with no special handling
+beyond switching the transformer choice. Both computational time and VRAM use stay manageable on a GPU
+because `nufftax` runs the NUFFT inside the JAX jit/vmap pipeline.
 
-If your dataset contains many visibilities, you should start by working through this example and the other examples
-in the `interferometer` folder. Once you are comfortable with the API, the `feature/pixelization` package provides a
-guided path toward efficiently modeling large interferometric datasets.
-
-The threshold between a dataset having many visibilities and therefore requiring pixelized reconstructions, or
-being small enough to be modeled with light profiles, is around **10,000 visibilities**.
+Pixelized reconstructions (see `features/pixelization`) remain the right tool when the galaxy has complex,
+irregular morphology that simple light profiles cannot capture. They are no longer required purely because
+the dataset is large.
 
 __Contents__
 
 - **JAX:** Overview of JAX GPU/CPU acceleration for fast model fitting.
-- **Number of Visibilities:** Discussion of dataset size and when to use pixelized reconstructions.
+- **NUFFT (nufftax):** A JAX-native Non-Uniform FFT, used for the image to uv-plane transform of light profiles.
+- **Number of Visibilities:** Discussion of dataset size; the same workflow scales to many millions of visibilities.
 - **Google Colab Setup:** Setting up the environment for Google Colab.
 - **Imports:** Standard imports used across workspace examples.
 - **Mask (Real Space):** Defining the real-space mask for interferometer modeling.
@@ -132,14 +147,17 @@ We begin by loading an `Interferometer` dataset from FITS, three ingredients are
 - `noise_map.fits`: per-visibility complex RMS
 - `uv_wavelengths.fits`: (u, v) sampling of the interferometer in wavelengths
 
-We must also choose a transformer:
+We must also choose a transformer for mapping the real-space image to visibilities:
 
-- `TransformerDFT`: exact Discrete FT (robust, slower for large n_vis).
-- `TransformerNUFFT`: approximate Non-Uniform FFT (fast, accurate for large n_vis) using the pynufft library.
+- `TransformerNUFFT`: JAX-native Non-Uniform FFT (default, backed by `nufftax`). Recommended for any
+  dataset size — runs at full GPU speed for millions of visibilities.
+- `TransformerDFT`: exact Discrete FT. Slower than the NUFFT for large `n_vis`, but useful as a reference
+  for verification and for the pixelized reconstruction's sparse-operator workflow (see
+  `features/pixelization`).
 
-We load a low resolution Square Mile Array (SMA) dataset for this example, which has just
-273 visibilities. This has so few visibilities that we can use the exact DFT transformer without
-the computation being too slow (for larger datasets with many visibilities the NUFFT transformer is recommended).
+We load a low resolution Square Mile Array (SMA) dataset for this example, which has just 273 visibilities.
+We use `TransformerNUFFT` so that this example reflects the recommended workflow at any visibility count;
+for 273 visibilities `TransformerDFT` would also work and produce a near-identical result.
 """
 dataset_name = "simple"
 dataset_path = Path("dataset") / "interferometer" / dataset_name
@@ -165,7 +183,7 @@ dataset = ag.Interferometer.from_fits(
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
-    transformer_class=ag.TransformerDFT,
+    transformer_class=ag.TransformerNUFFT,
 )
 
 aplt.subplot_interferometer_dirty_images(dataset=dataset)
@@ -279,9 +297,9 @@ packages of the workspace contain all the information you need to analyze your r
 
 __Model Your Own Galaxy__
 
-If you have your own interferometer data of a galaxy, and it has less than ~10000 visibilities, you are now ready to
-model it yourself by adapting the code above and simply inputting the path to your own .fits files into
-the `Interferometer.from_fits()` function.
+If you have your own interferometer data of a galaxy — at any visibility count, from a handful up to the
+hundreds of millions typical of ALMA — you are ready to model it yourself by adapting the code above and
+inputting the path to your own .fits files into the `Interferometer.from_fits()` function.
 
 A few things to note, with full details on data preparation provided in the main workspace documentation:
 
@@ -355,7 +373,7 @@ simulator = ag.SimulatorInterferometer(
     uv_wavelengths=uv_wavelengths,
     exposure_time=300.0,  # Length of observation in seconds, higher time = higher S/N
     noise_sigma=1000.0,  # RMS of the complex Gaussian noise added to the visibilities
-    transformer_class=ag.TransformerDFT,  # keep consistent with your modeling choice
+    transformer_class=ag.TransformerNUFFT,  # JAX-native NUFFT (nufftax) — scales to many visibilities
 )
 
 galaxies = ag.Galaxies([galaxy])


### PR DESCRIPTION
## Summary

Mirrors the autolens_workspace interferometer prose refresh for the autogalaxy interferometer package. Light-profile interferometer modeling now runs at full GPU speed at any visibility count thanks to `nufftax` (the new JAX-native backend for `TransformerNUFFT`, https://github.com/GragasLab/nufftax). The 10,000-visibility ceiling on light-profile fitting and the pixelization-for-performance framing are removed.

There is no SLaM pipeline in this workspace, so changes are prose + transformer-default updates only.

## Scripts Changed

- `scripts/interferometer/start_here.py` — new `__NUFFT__` section crediting nufftax; rewrote `__Number of Visibilities__`; dropped the "<10000 visibilities" caveat; demo transformer switched to `TransformerNUFFT`
- `scripts/interferometer/modeling.py` — Number-of-Visibilities rewrite; demo transformer switched to `TransformerNUFFT`; `Features` recommendation reframed (pixelizations for morphology, not speed)
- `scripts/interferometer/simulator.py` — simulator demo switched to `TransformerNUFFT` with credit to nufftax
- `scripts/interferometer/fit.py`, `likelihood_function.py` — narrative refresh + `TransformerNUFFT` switch in `Interferometer.from_fits()`

## Test Plan

- [x] Smoke tests pass under `PYAUTO_TEST_MODE=2 PYAUTO_SMALL_DATASETS=1 PYAUTO_FAST_PLOTS=1` for `start_here.py`, `modeling.py`, `simulator.py`
- [x] `scripts/check_sizes.sh` reports all scripts within tolerance

Mirror of Jammy2211/autolens_workspace#146 for autogalaxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)