### PR TITLE
chore(scripts): Phase 3 use_jax=True adoption sweep — 3 scripts

### DIFF
--- a/scripts/imaging/features/extra_galaxies/modeling.py
+++ b/scripts/imaging/features/extra_galaxies/modeling.py
@@ -220,7 +220,7 @@ search = af.Nautilus(
     iterations_per_quick_update=20000,
 )
 
-analysis = ag.AnalysisImaging(dataset=dataset)
+analysis = ag.AnalysisImaging(dataset=dataset, use_jax=True)
 
 result = search.fit(model=model, analysis=analysis)
 

--- a/scripts/imaging/features/multi_gaussian_expansion/modeling.py
+++ b/scripts/imaging/features/multi_gaussian_expansion/modeling.py
@@ -242,6 +242,7 @@ Create the `AnalysisImaging` object defining how the via Nautilus the model is f
 """
 analysis = ag.AnalysisImaging(
     dataset=dataset,
+    use_jax=True,
 )
 
 """

--- a/scripts/imaging/features/pixelization/source_science.py
+++ b/scripts/imaging/features/pixelization/source_science.py
@@ -96,7 +96,7 @@ search = af.Nautilus(
     iterations_per_quick_update=50000,
 )
 
-analysis = ag.AnalysisImaging(dataset=dataset)
+analysis = ag.AnalysisImaging(dataset=dataset, use_jax=True)
 
 result = search.fit(model=model, analysis=analysis)
 


### PR DESCRIPTION
## Summary
Phase 3 of `z_features/jax_visualization.md` (now archived). Phase 2 (PyAutoFit #1278) made `use_jax=True` sufficient — visualization auto-follows via the new sentinel default. This is a light sweep filling the few remaining gaps in autogalaxy_workspace where companion scripts in the same feature directory already had `use_jax=True` but a sibling didn't. The autogalaxy workspace was already well-covered after Phase 2 incidental adoption (31/35 eligible scripts) — this PR closes the consistency gap.

## Scripts Changed

- `scripts/imaging/features/multi_gaussian_expansion/modeling.py` — bare `AnalysisImaging` call; every other `imaging/features/*/modeling.py` had already adopted, this was the lone holdout
- `scripts/imaging/features/extra_galaxies/modeling.py` — first Analysis call (around line 223) now matches the second call (around line 401) which already had `use_jax=True`
- `scripts/imaging/features/pixelization/source_science.py` — bare `AnalysisImaging` call; interferometer equivalent already adopted

## Skip list — files INTENTIONALLY not edited

- `ellipse/modeling.py` — explicit `use_jax=False` pending production stability confirmation of `AnalysisEllipse` JAX support
- Simulators, `fit.py`, `likelihood_function.py`, aggregator scripts — no Analysis fit

## Roadmap context
Phases 0-2 shipped May 2026. Phase 4 (subprocess visualization) and Phase 5 (live Colab/Jupyter cell) remain explicit stubs.

## Test Plan
- [x] Smoke tests: 6/6 pass on `autogalaxy_workspace` (20/20 across the 3 workspaces in this sweep).
- [x] `PYAUTO_DISABLE_JAX=1` in smoke defaults forces `use_jax=False`, so smoke verifies kwarg parsing only — not the JIT path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)