### PR TITLE
docs: refresh Basis demo in profiles/light.py after #425

### DIFF
--- a/.script_sizes.json
+++ b/.script_sizes.json
@@ -29,7 +29,7 @@
   "scripts/guides/plot/simulator.py": 4463,
   "scripts/guides/plot/start_here.py": 4418,
   "scripts/guides/profiles/__init__.py": 0,
-  "scripts/guides/profiles/light.py": 24123,
+  "scripts/guides/profiles/light.py": 24464,
   "scripts/guides/results/__init__.py": 0,
   "scripts/guides/results/_quick_fit.py": 2554,
   "scripts/guides/results/aggregator/__init__.py": 0,

--- a/scripts/guides/profiles/light.py
+++ b/scripts/guides/profiles/light.py
@@ -252,44 +252,45 @@ galaxy's light is decomposed into a sum of many concentric Gaussians at fixed ce
 ellipticities but with increasing widths — together they reproduce arbitrary radial profiles
 the standard parametric forms cannot capture.
 
-The `Basis` constructor takes a `profile_list` of any light or mass profiles:
+The `Basis` constructor takes a `profile_list` of any light or mass profiles.  Below we
+build a four-Gaussian MGE with shared centre and ellipticity, sigmas that span an order of
+magnitude, and explicit decreasing `intensity` so the innermost Gaussian dominates the
+core and the wider ones add the outer envelope.  Standard `ag.lp.Gaussian` profiles are
+used here so the demo image is meaningful; in an actual fit you would swap these for
+`ag.lp_linear.Gaussian` (see the note after the plot).
 """
 basis = ag.lp_basis.Basis(
     profile_list=[
-        ag.lp_linear.Gaussian(
+        ag.lp.Gaussian(
             centre=(0.0, 0.0),
             ell_comps=ag.convert.ell_comps_from(axis_ratio=0.8, angle=45.0),
+            intensity=1.0,
             sigma=0.05,
         ),
-        ag.lp_linear.Gaussian(
+        ag.lp.Gaussian(
             centre=(0.0, 0.0),
             ell_comps=ag.convert.ell_comps_from(axis_ratio=0.8, angle=45.0),
+            intensity=0.5,
             sigma=0.15,
         ),
-        ag.lp_linear.Gaussian(
+        ag.lp.Gaussian(
             centre=(0.0, 0.0),
             ell_comps=ag.convert.ell_comps_from(axis_ratio=0.8, angle=45.0),
+            intensity=0.25,
             sigma=0.4,
         ),
-        ag.lp_linear.Gaussian(
+        ag.lp.Gaussian(
             centre=(0.0, 0.0),
             ell_comps=ag.convert.ell_comps_from(axis_ratio=0.8, angle=45.0),
+            intensity=0.1,
             sigma=1.0,
         ),
     ]
 )
 
-"""
-Because the constituents are `LightProfileLinear` instances they have no concrete
-`intensity` value yet — the intensity is the thing the inversion would solve for during a
-fit.  To plot what the basis looks like *as a model component* we wrap it as the `bulge` of
-a `Galaxy` and plot the galaxy's image, which is how the basis is used in practice:
-"""
-basis_galaxy = ag.Galaxy(redshift=0.5, bulge=basis)
-
 aplt.plot_array(
-    array=basis_galaxy.image_2d_from(grid=grid),
-    title="Basis Image (4-Gaussian MGE, plotted via Galaxy)",
+    array=basis.image_2d_from(grid=grid),
+    title="Basis Image (4-Gaussian MGE)",
 )
 
 """
@@ -297,10 +298,14 @@ Two things make `Basis` powerful:
 
 - It slots into a `Galaxy` exactly like a `Sersic` would — once wrapped, the rest of the
   modelling code doesn't have to know it's looking at four Gaussians under the hood.
-- When *every* constituent profile is a `LightProfileLinear` (as in the example above), all
-  of their `intensity` values are solved together in a **single combined inversion** at each
+- When the constituents are `LightProfileLinear` instances (e.g. `ag.lp_linear.Gaussian`)
+  rather than the standard `ag.lp.Gaussian` used in the demo above, all of their
+  `intensity` values are solved together in a **single combined inversion** at each
   likelihood evaluation.  This means an MGE built from, say, 30 Gaussians adds only the
   shared geometric parameters to the non-linear search rather than 30 extra intensities.
+  The demo above uses standard Gaussians purely so the image is non-zero on a static
+  plot — in a real fit you would build the basis from `ag.lp_linear.Gaussian` and let the
+  inversion solve the intensities.
 
 The full MGE workflow — choosing how many Gaussians to use, how to space their `sigma`
 values, and how the inversion plays with regularisation — is documented in:


### PR DESCRIPTION
## Summary

Workspace follow-up to PyAutoGalaxy #425 (`profile-return-type-fixes`). Now that
`Basis.image_2d_from` returns `Array2D` uniformly even when the basis is composed entirely
of `LightProfileLinear` constituents, the Galaxy-wrap workaround in
`scripts/guides/profiles/light.py` is no longer needed and can be removed.

Auditing the workaround removal surfaced a pedagogical issue: the Basis demo was
plotting an all-zeros map (the `lp_linear.Gaussian` constituents have no intensities yet
— the inversion would solve those at fit time, but in the standalone demo the image is
just `xp.zeros(...)`). Switching the demo to standard `ag.lp.Gaussian` with explicit
decreasing intensities produces a meaningful MGE shape, with a follow-on note explaining
that you would use `ag.lp_linear.Gaussian` in an actual fit.

Part of autolens_workspace #182 — the same fix lands on autolens_workspace in a
parallel PR.

## Scripts Changed

- `scripts/guides/profiles/light.py` — Basis section: swap four `ag.lp_linear.Gaussian`
  constituents for four `ag.lp.Gaussian` with explicit decreasing intensities; drop the
  `basis_galaxy = ag.Galaxy(...)` wrap; plot `basis.image_2d_from(grid=grid)` directly;
  rewrite the surrounding prose for the standard-vs-linear framing.
- `.script_sizes.json` — refreshed snapshot.

## Test Plan

- [ ] Smoke run: `PYAUTO_TEST_MODE=2 ... python scripts/guides/profiles/light.py` exits 0
- [ ] Workspace `smoke_tests.txt` curated set still passes
- [ ] `scripts/check_sizes.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)