### PR TITLE
fix(interferometer): use TransformerDFT for sparse-operator preparation script

### DIFF
--- a/scripts/interferometer/features/pixelization/many_visibilities_preparation.py
+++ b/scripts/interferometer/features/pixelization/many_visibilities_preparation.py
@@ -84,7 +84,7 @@ dataset = ag.Interferometer.from_fits(
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
-    transformer_class=ag.TransformerNUFFT,
+    transformer_class=ag.TransformerDFT,
 )
 
 """


### PR DESCRIPTION
## Summary
`many_visibilities_preparation.py` in `autogalaxy_workspace` was the only script in `scripts/interferometer/features/pixelization/` still building its dataset with `transformer_class=ag.TransformerNUFFT`. Under the nufftax-backed default transformer, `apply_sparse_operator` raises `NotImplementedError` — the strict-adjoint NUFFT has a different scale from the dirty image the sparse-operator solver expects. Switch to `TransformerDFT`, matching the canonical DFT + sparse pairing used by every sibling script in the folder and the parallel `autolens_workspace` script (which was already migrated).

## Scripts Changed
- `scripts/interferometer/features/pixelization/many_visibilities_preparation.py` — `transformer_class=ag.TransformerNUFFT` → `ag.TransformerDFT` to unblock `apply_sparse_operator`.

## Test Plan
- [x] Script runs end-to-end under `PYAUTO_TEST_MODE=2` smoke env stack; exits 0; writes `nufft_precision_operator_3.0.npy`.
- [x] Workspace smoke tests pass via `/smoke_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)