### PR TITLE
triage 2026-05-20 cleanup: park interferometer MGE singular matrix

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -30,3 +30,4 @@
 - imaging/features/pixelization/modeling # NEEDS_FIX 2026-04-10 - LinAlgError: matrix not positive definite in pixelization modeling
 - autogalaxy_workspace/scripts/imaging/modeling # NEEDS_FIX 2026-04-10 - KeyError on ('galaxies','galaxy','bulge','ell_comps'...) kwargs after API drift in top-level imaging/modeling.py
 - interferometer/features/pixelization/modeling # NEEDS_FIX 2026-04-10 - LinAlgError: matrix not positive definite in interferometer pixelization modeling
+- interferometer/features/multi_gaussian_expansion/likelihood_function # NEEDS_FIX 2026-05-20 - LinAlgError: matrix singular in MGE inversion -> InversionException (known_numerical; same family as pixelization variants above)


### PR DESCRIPTION
## Summary
**Cluster G** from the 2026-05-20T18-55-23Z release-prep triage — `interferometer/features/multi_gaussian_expansion/likelihood_function.py` raises `numpy.linalg.LinAlgError: Matrix is singular` → `autoarray.exc.InversionException`. The auto-classifier already labels this `known_numerical`.

Same numerical family as the pixelization `LinAlgError: matrix not positive definite` entries already parked on 2026-04-10 (`imaging/features/pixelization/modeling`, `interferometer/features/pixelization/modeling`). The MGE curvature matrix is singular under the current simulator + grid combination; investigating the curvature path is a follow-up.

Add a matching NEEDS_FIX entry so the failure stops gating release-readiness.

## API Changes
None — single line in `config/build/no_run.yaml` only.
See full details below.

## Test Plan
- [ ] Next `autobuild run_all` no longer lists `interferometer/features/multi_gaussian_expansion/likelihood_function.py` as a failure.

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed
- `config/build/no_run.yaml` — one new NEEDS_FIX entry for interferometer MGE.

### Migration
None.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)