### PR TITLE
chore: remove fit_quantity config entry

### DIFF
--- a/config/visualize/plots.yaml
+++ b/config/visualize/plots.yaml
@@ -50,5 +50,3 @@ fit_interferometer:                        # Settings for plots of fits to inter
 fit_ellipse:                               # Settings for plots of ellipse fitting fits (e.g. FitEllipse)
   data : true                              # Plot the data of the ellipse fit?
   data_no_ellipse: true                    # Plot the data without the black data ellipses, which obscure noisy data?
-
-fit_quantity: {}                           # Settings for plots of fit quantities (e.g. FitQuantityPlotter).


### PR DESCRIPTION
## Summary

The `FitQuantity` / `AnalysisQuantity` stack has been archived in [PyAutoGalaxy](https://github.com/PyAutoLabs/PyAutoGalaxy)'s `feature/archive-quantity-package` PR. This workspace's `config/visualize/plots.yaml` carried a `fit_quantity: {}` line that referenced the deleted library section.

## Changes

- `config/visualize/plots.yaml` — removed the `fit_quantity: {}` line

## Test plan

- [x] `grep -rE 'fit_quantity' config/` returns zero hits
- [ ] After library PR merges, workspace smoke tests are expected to remain green (no script in this workspace used quantity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)