### PR TITLE
docs: add __JAX__ section to top-level start_here.py

### DIFF
--- a/start_here.py
+++ b/start_here.py
@@ -173,6 +173,81 @@ galaxies = ag.Galaxies(
 aplt.plot_array(array=galaxies.image_2d_from(grid=grid), title="Galaxies Image")
 
 """
+__JAX__
+
+**PyAutoGalaxy** runs on either **NumPy** (the default) or **JAX** (Google's
+array library with GPU support and just-in-time compilation). JAX makes
+galaxy model-fitting 10-100x faster on large grids, so the library uses it
+automatically wherever it helps.
+
+You do not have to do anything to opt in. If you installed `autogalaxy`
+with the JAX extra (`pip install autogalaxy[jax]` on Python 3.11+), the
+`AnalysisImaging` and `AnalysisInterferometer` classes you'll meet in the
+`__Galaxy Modeling__` section below default to `use_jax=True`. The
+non-linear search driver (Nautilus, dynesty, ...) batches parameter
+vectors and evaluates the likelihood through `jax.vmap(jax.jit(...))`
+internally. You'll see a one-time log line like `JAX: Applying vmap and
+jit to likelihood function -- may take a few seconds.` the first time a
+search starts; after that, evaluations re-use the compiled trace.
+
+If JAX is not installed, the analysis warns once and falls back to NumPy
+automatically. You can force NumPy explicitly with
+`ag.AnalysisImaging(dataset=dataset, use_jax=False)` or by setting
+`PYAUTO_DISABLE_JAX=1` — useful when debugging, where NumPy stack traces
+are easier to read than JAX traces.
+
+__When you write `@jax.jit` yourself__
+
+Pass `use_jax=True` to a simulator constructor and wrap your call in
+`@jax.jit` when you want to render many datasets fast — parameter sweeps,
+mock-data studies, batch figure generation:
+
+```python
+import jax
+
+simulator = ag.SimulatorImaging(
+    exposure_time=300.0, psf=psf, background_sky_level=0.1, use_jax=True
+)
+
+@jax.jit
+def simulate(galaxies):
+    return simulator.via_galaxies_from(galaxies=galaxies, grid=grid)
+```
+
+The per-dataset-type `simulator.py` scripts (`scripts/imaging/simulator.py`,
+`scripts/interferometer/simulator.py`) each show this pattern in their
+`__JAX Variant__` section.
+
+For the advanced path — JIT-ing library methods directly
+(`galaxy.image_2d_from`, etc.) without going through a `Simulator` or
+`Analysis` — see the `scripts/guides/api/data_structures.py` guide. That
+covers the "JIT-it-yourself" pattern, including pytree registration the
+user does once before the first `@jax.jit`.
+
+__Return-type contract__
+
+When `use_jax=True`, the data structures you get back (`Imaging`,
+`FitImaging`, `Galaxies.image_2d_from(...)` results, ...) carry
+`jax.Array` data inside instead of `numpy.ndarray`. For nearly everything
+you'd do in a workspace — plotting, saving to `.fits`, comparing fit
+residuals — this is transparent: the plotters and FITS writers call
+`numpy.asarray()` internally and you see the same images and numbers you
+would on the NumPy path.
+
+What changes:
+
+- Arithmetic on JAX arrays stays on the JAX path. Direct calls into NumPy
+  (`np.sqrt(fit.residual_map.array)`) will host-transfer the array off
+  the GPU; not wrong, but slower than `jnp.sqrt(...)` if you're inside a
+  hot loop. For one-off analysis code, don't worry about it.
+- The `.array` property of `aa.Array2D` etc. is the raw backing array —
+  a `numpy.ndarray` on the NumPy path, a `jax.Array` on the JAX path.
+
+The `scripts/guides/api/data_structures.py` guide covers the wrapper-vs-
+raw-array distinction in detail.
+"""
+
+"""
 __Units__
 
 The units used throughout the galaxy structure literature vary, therefore lets quickly describe the units used in


### PR DESCRIPTION
## Summary

Adds the top-level `__JAX__` section to `start_here.py`, between `__Galaxies__` and `__Units__`. Code-light prose mirror of the autolens_workspace companion — explains when JAX runs by default (Analysis path), when the user writes `@jax.jit` themselves (simulators), and the return-type contract.

Phase 1 of `z_features/jax_user_intro.md`. Tracked in autolens_workspace#200.

## Scripts Changed
- `start_here.py` — new `__JAX__` section (~70 lines of prose + one illustrative `simulator.via_galaxies_from(use_jax=True)` snippet) inserted after `__Galaxies__`.

## Test Plan
- [x] `start_here.py` runs end-to-end on NumPy.
- [x] Smoke tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)