### PR TITLE
docs: __JAX__ sections in per-dataset scripts (imaging + interferometer)

### DIFF
--- a/scripts/imaging/fit.py
+++ b/scripts/imaging/fit.py
@@ -50,6 +50,20 @@ __Contents__
 - **Outputting Results:** Saving fit quantities to FITS files for later analysis.
 - **Modeling Results:** Links to modeling result analysis in the workspace.
 - **Wrap Up:** Summary of the FitImaging object and next steps.
+
+__JAX__
+
+This script constructs a `FitImaging` directly from galaxies and a dataset
+(no Analysis / no non-linear search). The fit works on either backend —
+quantities it computes (`fit.model_image`, `fit.residual_map`,
+`fit.log_likelihood`, ...) return `numpy.ndarray` on the default path or
+`jax.Array` if you constructed the upstream objects with `xp=jnp`.
+
+For the standard analysis-driven modeling path — where `AnalysisImaging`
+auto-enables `use_jax=True` and the search driver handles the JIT — see
+`start_here.py` / `modeling.py`. For the advanced path where you wrap your
+own `@jax.jit` around `FitImaging` construction, see `likelihood_function.py`'s
+`__JAX__` section and the `scripts/guides/api/data_structures.py` guide.
 """
 
 # from autoconf import setup_notebook; setup_notebook()

--- a/scripts/imaging/likelihood_function.py
+++ b/scripts/imaging/likelihood_function.py
@@ -371,6 +371,47 @@ analytic light profiles to fit the galaxy light.
 There are a number of other inputs features which slightly change the behaviour of this likelihood function, which
 are described in additional notebooks found in the `guides` package:
 
- - `over_sampling`: Oversampling the image grid into a finer grid of sub-pixels, which are all individually 
+ - `over_sampling`: Oversampling the image grid into a finer grid of sub-pixels, which are all individually
  ray-traced to the source-plane and used to evaluate the light profile more accurately.
+
+__JAX__
+
+The step-by-step likelihood you've just walked through can be JAX-
+accelerated by wrapping the whole construction in `@jax.jit`:
+
+```python
+import jax
+import jax.numpy as jnp
+
+# Triggering pytree registration: the easiest path is to instantiate an
+# AnalysisImaging at the top of the script, which runs its internal
+# _register_fit_imaging_pytrees() as a side effect.
+_ = ag.AnalysisImaging(dataset=dataset, use_jax=True)
+
+@jax.jit
+def my_log_likelihood(instance):
+    galaxies = ag.Galaxies(galaxies=instance.galaxies)
+    fit = ag.FitImaging(dataset=dataset, galaxies=galaxies)
+    return fit.log_likelihood
+```
+
+To validate the JAX path matches the NumPy chi-squared, use
+`Fitness._vmap` (production validation pattern — single `jax.jit(fn)(concrete)`
+hides un-threaded `xp` sites that `vmap(jit(call))` exposes):
+
+```python
+from autofit.non_linear.fitness import Fitness
+
+fitness = Fitness(
+    model=model,
+    analysis=ag.AnalysisImaging(dataset=dataset),
+    fom_is_log_likelihood=True,
+)
+log_l_jax = fitness._vmap(jnp.array([instance_parameters]))[0]
+```
+
+For the canonical Analysis-driven modeling path (zero JAX code on your
+side), see `start_here.py` / `modeling.py`. For JIT-ing library methods
+directly without going through `FitImaging`, see
+`scripts/guides/api/data_structures.py`.
 """

--- a/scripts/imaging/simulator.py
+++ b/scripts/imaging/simulator.py
@@ -186,4 +186,46 @@ ag.output_to_json(
 
 """
 The dataset can be viewed in the folder `autogalaxy_workspace/imaging/simple`.
+
+__JAX Variant__
+
+For an order-of-magnitude speedup on large or repeated simulations
+(parameter sweeps, mock-data studies, batch figure generation), construct
+the simulator with `use_jax=True` and wrap your call in `@jax.jit`. The
+simulator handles pytree registration internally.
+
+```python
+import jax
+
+simulator_jax = ag.SimulatorImaging(
+    exposure_time=300.0,
+    psf=psf,
+    background_sky_level=0.1,
+    add_poisson_noise_to_data=True,
+    use_jax=True,
+)
+
+@jax.jit
+def simulate(galaxies):
+    return simulator_jax.via_galaxies_from(galaxies=galaxies, grid=grid)
+
+dataset_jax = simulate(galaxies)   # Imaging with jax.Array data
+```
+
+The `dataset_jax.data.array` is a `jax.Array`; `aplt.fits_imaging` and the
+plotters call `numpy.asarray()` internally, so saving / plotting works
+without manual conversion.
+
+Two notes:
+
+- Eager `simulator_jax.via_galaxies_from(galaxies, grid)` (no `@jax.jit`)
+  already runs on JAX and is sufficient for one-off simulations. The
+  `@jax.jit` wrap is only beneficial when you call the function many times.
+- The `@jax.jit` wrap is currently blocked by a pre-existing `Array2D.native`
+  jit-incompatibility in autoarray's slim/native reshape. Eager JAX works
+  today; the `@jax.jit` shown above will work once a separate refactor
+  task lands.
+
+See `scripts/guides/api/data_structures.py` for the broader "JIT-it-
+yourself" pattern.
 """

--- a/scripts/imaging/start_here.py
+++ b/scripts/imaging/start_here.py
@@ -14,14 +14,17 @@ see the `start_here_group.ipynb` and `start_here_cluster.ipynb` examples.
 
 __JAX__
 
-PyAutoGalaxy uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
+PyAutoGalaxy runs imaging model-fits on JAX by default. If you installed
+`autogalaxy[jax]`, the `ag.AnalysisImaging(dataset=dataset)` line below
+auto-enables `use_jax=True`; expect 10-30 minutes on CPU, 1-10 minutes on
+GPU, vs 1-2 hours on pure NumPy. If you do not have a GPU locally, Google
+Colab provides free GPUs.
 
-If you don’t have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
-
-We also show how to simulate galaxy imaging. This is useful for building machine learning training datasets,
-or for investigating imaging effects in a controlled way.
+For the broader JAX principles (when you write `@jax.jit` yourself, the
+return-type contract, how to opt out for debugging), see the top-level
+`autogalaxy_workspace/start_here.py` `__JAX__` section. For a runnable
+`@jax.jit + SimulatorImaging(use_jax=True)` example, see the
+`__JAX Variant__` section at the end of `scripts/imaging/simulator.py`.
 
 __Contents__
 
@@ -236,11 +239,15 @@ the model to the imaging data.
 
 __JAX__
 
-PyAutoGalaxy uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
+`ag.AnalysisImaging` defaults to `use_jax=True` when JAX is installed.
+The search driver wraps the likelihood in `jax.vmap(jax.jit(...))` —
+batches of parameter vectors evaluate in parallel on a single GPU call.
+Watch for `JAX: Applying vmap and jit to likelihood function -- may take
+a few seconds.` in the log; that's the JIT compile starting, after which
+evaluations re-use the compiled trace.
 
-If you don’t have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
+Force NumPy with `use_jax=False` (or `PYAUTO_DISABLE_JAX=1`) when
+debugging — NumPy stack traces are easier to read than JAX traces.
 
 __Iterations Per Update__
 

--- a/scripts/interferometer/fit.py
+++ b/scripts/interferometer/fit.py
@@ -24,6 +24,15 @@ __Contents__
 - **Figures of Merit:** Computing chi-squared, noise normalization, and log likelihood values.
 - **Galaxy Quantities:** Accessing per-galaxy model visibilities and images from the fit.
 - **Outputting Results:** Saving fit results to FITS files for later use.
+
+__JAX__
+
+`FitInterferometer` runs on either NumPy or JAX. For the standard
+analysis-driven path — where `AnalysisInterferometer` auto-enables
+`use_jax=True` and the search driver handles the JIT — see `start_here.py`
+/ `modeling.py`. For the JIT-it-yourself path around individual library
+methods, see `scripts/guides/api/data_structures.py`.
+
 """
 
 from autoconf import jax_wrapper  # Sets JAX environment before other imports

--- a/scripts/interferometer/likelihood_function.py
+++ b/scripts/interferometer/likelihood_function.py
@@ -378,6 +378,33 @@ analytic light profiles to fit the galaxy light.
 There are a number of other inputs features which slightly change the behaviour of this likelihood function, which
 are described in additional notebooks found in the `guides` package:
 
- - `over_sampling`: Oversampling the image grid into a finer grid of sub-pixels, which are all individually 
+ - `over_sampling`: Oversampling the image grid into a finer grid of sub-pixels, which are all individually
  ray-traced to the source-plane and used to evaluate the light profile more accurately.
+
+__JAX__
+
+The step-by-step interferometer likelihood you've just walked through
+can be JAX-accelerated by wrapping construction in `@jax.jit`:
+
+```python
+import jax
+import jax.numpy as jnp
+
+# Triggering pytree registration via Analysis init as a side effect.
+_ = ag.AnalysisInterferometer(dataset=dataset, use_jax=True)
+
+@jax.jit
+def my_log_likelihood(instance):
+    galaxies = ag.Galaxies(galaxies=instance.galaxies)
+    fit = ag.FitInterferometer(dataset=dataset, galaxies=galaxies)
+    return fit.log_likelihood
+```
+
+Use `TransformerDFT` (the default) under JAX — `TransformerNUFFT` is not
+JAX-traceable. To validate the JAX log-likelihood matches the NumPy
+chi-squared you derived above, use `Fitness._vmap(jnp.array([parameters]))`.
+
+For the canonical Analysis-driven path (zero JAX code on your side),
+see `start_here.py` / `modeling.py`. For JIT-ing library methods directly,
+see `scripts/guides/api/data_structures.py`.
 """

--- a/scripts/interferometer/simulator.py
+++ b/scripts/interferometer/simulator.py
@@ -187,4 +187,45 @@ ag.output_to_json(
 
 """
 The dataset can be viewed in the folder `autogalaxy_workspace/imaging/simple`.
+
+__JAX Variant__
+
+For fast repeated interferometer simulations, construct the simulator
+with `use_jax=True` and wrap the call in `@jax.jit`. The simulator
+handles pytree registration internally.
+
+```python
+import jax
+import jax.numpy as jnp
+
+simulator_jax = ag.SimulatorInterferometer(
+    uv_wavelengths=uv_wavelengths,
+    exposure_time=300.0,
+    noise_sigma=0.1,
+    transformer_class=ag.TransformerDFT,  # NUFFT (pynufft) is not JAX-traceable
+    use_jax=True,
+)
+
+@jax.jit
+def simulate(galaxies):
+    galaxy_obj = ag.Galaxies(galaxies=galaxies)
+    image = galaxy_obj.image_2d_from(grid=real_space_grid, xp=jnp)
+    return simulator_jax.via_image_from(image=image)
+
+dataset_jax = simulate(galaxies)   # Interferometer with jax.Array visibilities
+```
+
+Two notes:
+
+- Use `TransformerDFT` (the default) under JAX. `TransformerNUFFT`
+  (pynufft) is faster on large UV sets but is not JAX-traceable; the
+  `nufftax` replacement is a research path (see
+  `autolens_workspace_test/scripts/interferometer/nufft.py`).
+- Eager `simulator_jax.via_image_from(image)` already runs on JAX without
+  the `@jax.jit` wrap; the JIT wrap is currently blocked by a pre-existing
+  `Array2D.native` autoarray limitation. Eager use works today; the
+  `@jax.jit` wrap shown above will work once a separate refactor lands.
+
+See `scripts/guides/api/data_structures.py` for the broader "JIT-it-
+yourself" pattern.
 """

--- a/scripts/interferometer/start_here.py
+++ b/scripts/interferometer/start_here.py
@@ -14,14 +14,18 @@ see the `start_here_group.ipynb` and `start_here_cluster.ipynb` examples.
 
 __JAX__
 
-PyAutoGalaxy uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
+PyAutoGalaxy runs interferometer model-fits on JAX by default. If you
+installed `autogalaxy[jax]`, `ag.AnalysisInterferometer(dataset=dataset)`
+below auto-enables `use_jax=True`. Use `TransformerDFT` (the default)
+under JAX — `TransformerNUFFT` (pynufft) is faster on large UV sets but
+is not JAX-traceable; the `nufftax` replacement (see `__NUFFT (nufftax)__`
+below) is a research path tracking that.
 
-If you don’t have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
-
-We also show how to simulate interferometer datasets. This is useful for building machine
-learning training datasets, or for investigating galaxy structure in a controlled way.
+For broader JAX principles (when you write `@jax.jit` yourself, the
+return-type contract), see the top-level `autogalaxy_workspace/start_here.py`
+`__JAX__` section. For a runnable `@jax.jit + SimulatorInterferometer(use_jax=True)`
+example, see the `__JAX Variant__` section at the end of
+`scripts/interferometer/simulator.py`.
 
 __NUFFT (nufftax)__
 
@@ -229,11 +233,10 @@ Nautilus to fit the model to the interferometer data.
 
 __JAX__
 
-PyAutoGalaxy uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
-
-If you don’t have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
+`ag.AnalysisInterferometer` defaults to `use_jax=True` when JAX is
+installed. The search driver wraps the likelihood in `jax.vmap(jax.jit(...))`.
+Force NumPy with `use_jax=False` (or `PYAUTO_DISABLE_JAX=1`) when
+debugging.
 
 **Run Time Error:** On certain operating systems (e.g. Windows, Linux) and Python versions, the code below may produce
 an error. If this occurs, see the `autogalaxy_workspace/guides/modeling/bug_fix` example for a fix.


### PR DESCRIPTION
## Summary

Phase 4a + 4b of `z_features/jax_user_intro.md` bundled into one PR. Adds `__JAX__` prose and `__JAX Variant__` runnable code blocks across the two core per-dataset script sets — `imaging` and `interferometer` — in `scripts/{imaging,interferometer}/{start_here,simulator,fit,likelihood_function}.py`.

Per-dataset `start_here.py` scripts refresh stale `__JAX__` blocks that predated the Phase 0 contract; `simulator.py` scripts gain `__JAX Variant__` blocks using the post-Phase-2 `ag.SimulatorImaging(use_jax=True)` / `ag.SimulatorInterferometer(use_jax=True)` APIs that landed in PyAutoArray#335, #336 and PyAutoGalaxy#442, #443.

Mirror of `autolens_workspace#202` (PR #203 — already merged).

## Scripts Changed
- `scripts/imaging/start_here.py` — refresh 2 stale `__JAX__` blocks
- `scripts/imaging/simulator.py` — new `__JAX Variant__` (`SimulatorImaging(use_jax=True)`)
- `scripts/imaging/fit.py` — `__JAX__` prose
- `scripts/imaging/likelihood_function.py` — `__JAX__` section with `@jax.jit` recipe + `Fitness._vmap` validation
- `scripts/interferometer/start_here.py` — refresh 2 `__JAX__` blocks + TransformerDFT/NUFFT caveat
- `scripts/interferometer/simulator.py` — new `__JAX Variant__` (`SimulatorInterferometer(use_jax=True)`)
- `scripts/interferometer/fit.py` — `__JAX__` prose
- `scripts/interferometer/likelihood_function.py` — `__JAX__` section

## Test Plan

- [x] All 8 files compile cleanly via `py_compile`
- [x] `scripts/check_sizes.sh` clean
- [x] Simulator scripts run end-to-end with `PYAUTO_TEST_MODE=1`

## Notes

`@jax.jit` wrap of `via_image_from` is currently blocked by a pre-existing `Array2D.native` autoarray limitation (same as the autolens companion); eager JAX use works today. Flagged in each `__JAX Variant__` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)