### PR TITLE
docs: __JAX__ in autogalaxy deferred (multi + guides mirror)

### DIFF
--- a/scripts/guides/data_structures.py
+++ b/scripts/guides/data_structures.py
@@ -365,9 +365,80 @@ print(deflections_yx_2d.slim[0, :])
 """
 The role of the terms `slim` and `native` can be thought of in the same way as for scalar quantities. 
 
-For a scalar, the `slim` property gives every scalar value as a 1D ndarray for every unmasked pixel. For a vector we 
-still get an ndarray of every unmasked pixel, however each entry now contains two entries: the vector of (y,x) values. 
+For a scalar, the `slim` property gives every scalar value as a 1D ndarray for every unmasked pixel. For a vector we
+still get an ndarray of every unmasked pixel, however each entry now contains two entries: the vector of (y,x) values.
 
 For a `native` property these vectors are shown on an image-plane 2D grid where again each pixel
 contains a (y,x) vector.
+
+__JAX__
+
+PyAutoGalaxy runs on either NumPy (the default) or JAX. The data
+structures you've met above are *backend-polymorphic* — wrappers
+around a numerical array that can be `numpy.ndarray` or `jax.Array`
+depending on how the structure was constructed.
+
+You can always reach the raw backing array via `.array`:
+
+```python
+grid = ag.Grid2D.uniform(shape_native=(100, 100), pixel_scales=0.05)
+print(type(grid.array))          # numpy.ndarray on the default path
+```
+
+__When the backing becomes `jax.Array`__
+
+Three situations switch the backing to `jax.Array`:
+
+1. The structure comes back from a JAX-accelerated `Analysis(use_jax=True)`
+   fit (`fit.residual_map.array`, `fit.model_image.array`, ...).
+2. The structure comes back from a `Simulator(use_jax=True)` simulation.
+3. You constructed it inside a JAX-traced function with `xp=jnp`.
+
+The Python-level wrapper is the same `aa.Array2D` / `aa.Grid2D` in all
+cases — only the underlying array type changes.
+
+__Host transfer (the JAX → NumPy boundary)__
+
+Most things you do convert back to NumPy transparently: plotting,
+`.fits` writing, `.copy()`, `.tolist()`. Direct NumPy arithmetic
+(`np.sqrt(fit.residual_map.array)`) transfers off the GPU — use
+`jnp.sqrt(...)` for hot loops, don't worry about it for one-off code.
+
+__The not-pytree rule__
+
+If you write your own `@jax.jit` function and try to return an
+`aa.Array2D` (or `aa.Grid2DIrregular`) from inside it, the JIT
+boundary may fail. The workaround: return the raw `.array` from inside
+the jit and rewrap on the host:
+
+```python
+@jax.jit
+def my_image_fn(galaxies, grid):
+    return galaxies.image_2d_from(grid=grid, xp=jnp).array   # raw jax.Array
+
+arr = my_image_fn(galaxies, grid)
+img_wrapped = ag.Array2D(values=arr, mask=grid.mask)
+```
+
+You only encounter this when *you* write the `@jax.jit` — the library
+handles its own returns correctly.
+
+For the canonical "JIT-it-yourself" deep-dive (decorator vs `jax.jit(bound_method)`,
+cache-identity considerations, the `@jax.jit + xp=jnp` pairing rule),
+see the autolens companion at
+`autolens_workspace/scripts/guides/lens_calc.py` `__JAX__` section.
+The patterns there apply equally to autogalaxy primitives — just
+`Galaxy` / `Galaxies` instead of `Tracer` / `LensCalc`.
+
+__Summary__
+
+| You construct / receive | Backing type |
+|---|---|
+| `ag.Grid2D.uniform(shape_native, pixel_scales)` | `numpy.ndarray` |
+| `fit = analysis.fit_from(instance)` from `AnalysisImaging(use_jax=True)` | `jax.Array` |
+| `dataset = simulator.via_galaxies_from(...)` from `SimulatorImaging(use_jax=True)` | `jax.Array` |
+| `galaxies.image_2d_from(grid=jnp_grid, xp=jnp)` inside your own `@jax.jit` | `jax.Array` |
+
+`.array` is the safe accessor for the raw backing. Plotting and
+`.fits` writers handle the conversion transparently.
 """

--- a/scripts/guides/galaxies.py
+++ b/scripts/guides/galaxies.py
@@ -445,8 +445,70 @@ Modeling results have some specific functionality and use cases, which are descr
 
 __Wrap Up__
 
-This tutorial explained how to compute the results of an inferred model from a galaxies. 
+This tutorial explained how to compute the results of an inferred model from a galaxies.
 
-We have learnt how to extract individual galaxies and light profiles from the results of 
+We have learnt how to extract individual galaxies and light profiles from the results of
 a model-fit and use these objects to compute specific quantities of each component.
+
+__JAX__
+
+When you write your own `@jax.jit` around a function that takes a
+`Galaxy` or `Galaxies` as an argument, JAX needs to flatten/unflatten
+that object across the JIT boundary — i.e. the class must be registered
+as a JAX pytree. The library handles this for you automatically in two
+situations:
+
+1. You constructed an `Analysis` with `use_jax=True` (the default for
+   modeling fits). Its first `fit_from` call walks the dataset and
+   registers every reachable `Galaxy` / profile class.
+2. You constructed a `Simulator` with `use_jax=True` and made a call —
+   same walk happens.
+
+After either, every `Galaxy`, `LightProfile`, `MassProfile` of the same
+class is JIT-safe in the current process. You never call
+`register_instance_pytree(Galaxy)` yourself.
+
+__The "no Analysis or Simulator handy" case__
+
+For a quick exploration script or a custom forward model that doesn't go
+through `Simulator`, you may want to JIT a function that takes a
+`Galaxy` as a traced argument:
+
+```python
+@jax.jit
+def galaxy_image(galaxy, grid):
+    return galaxy.image_2d_from(grid=grid, xp=jnp).array
+```
+
+Without prior pytree registration this fails the first time `galaxy` is
+traced. Workaround: trigger registration at the top of your script via
+an `Analysis` instantiation as a side effect:
+
+```python
+_ = ag.AnalysisImaging(dataset=dataset, use_jax=True)
+```
+
+After this, `galaxy_image` JITs cleanly.
+
+__Closure-captured galaxy: registration not needed__
+
+A way to JIT a galaxy-method call that does NOT need pytree
+registration: pass the galaxy as the bound method's `self`, not as an
+argument.
+
+```python
+jitted_image = jax.jit(galaxy.image_2d_from)   # bound method; assign ONCE
+arr = jitted_image(grid=grid, xp=jnp).array
+```
+
+Trade-off: you can't vary `galaxy` across calls and still hit the
+compilation cache. For parameter sweeps, use the argument form.
+
+For the full deep-dive on the bound-method vs traced-argument trade-off,
+cache-identity footguns, and the `@jax.jit + xp=jnp` pairing rule, see
+the autolens companion at
+`autolens_workspace/scripts/guides/lens_calc.py` `__JAX__` section. The
+patterns apply to autogalaxy primitives equally — substitute `Galaxy` /
+`Galaxies` for `Tracer` / `LensCalc`. The `.array` host-transfer
+mechanics live in `scripts/guides/data_structures.py`.
 """

--- a/scripts/multi/start_here.py
+++ b/scripts/multi/start_here.py
@@ -21,14 +21,17 @@ see the `start_here_group.ipynb` and `start_here_cluster.ipynb` examples.
 
 __JAX__
 
-PyAutoGalaxy uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
+PyAutoGalaxy runs multi-wavelength galaxy fits on JAX by default. The
+per-band `ag.AnalysisImaging(dataset=dataset, use_jax=True)` instances
+below auto-enable JAX, and the `af.FactorGraphModel(*analysis_factor_list,
+use_jax=True)` further down stitches them into the joint multi-band
+likelihood with JAX-aware broadcasting. If you installed
+`autogalaxy[jax]`, expect 1-10 minutes per band on GPU vs hours on CPU.
 
-If you don’t have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
-
-We also show how to simulate galaxy imaging. This is useful for building machine learning training datasets,
-or for investigating imaging effects in a controlled way.
+For the broader JAX principles see the top-level
+`autogalaxy_workspace/start_here.py` `__JAX__` section. Per-band
+`SimulatorImaging(use_jax=True)` usage is shown in
+`scripts/imaging/simulator.py` `__JAX Variant__`.
 
 __Contents__
 
@@ -258,11 +261,12 @@ When there are multiple datasets, a list of analysis objects is created, once fo
 
 __JAX__
 
-PyAutoGalaxy uses JAX under the hood for fast GPU/CPU acceleration. If JAX is installed with GPU
-support, your fits will run much faster (around 10 minutes instead of an hour). If only a CPU is available,
-JAX will still provide a speed up via multithreading, with fits taking around 20-30 minutes.
-
-If you don’t have a GPU locally, consider Google Colab which provides free GPUs, so your modeling runs are much faster.
+`AnalysisImaging(use_jax=True)` runs per-band; `FactorGraphModel(use_jax=True)`
+below stitches them into the joint multi-band likelihood. The non-linear
+search driver wraps the joint likelihood in `jax.vmap(jax.jit(...))` —
+batches of parameter vectors evaluate in parallel across all bands on a
+single GPU call. Force NumPy with `use_jax=False` (or `PYAUTO_DISABLE_JAX=1`)
+on either constructor when debugging.
 """
 analysis_list = [
     ag.AnalysisImaging(


### PR DESCRIPTION
## Summary

Phase 4c + 5e of `z_features/jax_user_intro.md` bundled. Closes the autogalaxy side of the series.

## Scripts Changed
- `scripts/multi/start_here.py` — refresh 2 stale `__JAX__` blocks per Phase 0 contract
- `scripts/guides/data_structures.py` — new `__JAX__` covering `.array` story, host transfer, the not-pytree rule + `.array` unwrap-rewrap workaround
- `scripts/guides/galaxies.py` — new `__JAX__` covering Galaxy / Galaxies pytree registration (auto via Analysis/Simulator; explicit Analysis-as-trigger workaround); closure-captured `self` vs traced argument

Both guide sections cross-reference `autolens_workspace/scripts/guides/lens_calc.py` for the canonical "JIT-it-yourself" deep-dive — autogalaxy has no `lens_calc.py` equivalent.

## Test Plan
- [x] All 3 files compile cleanly via `py_compile`
- [x] Both guide scripts run end-to-end with `PYAUTO_TEST_MODE=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)