### PR TITLE
docs: remove Array2D.native jit-blocked caveats from JAX variant blocks

### DIFF
--- a/scripts/imaging/simulator.py
+++ b/scripts/imaging/simulator.py
@@ -216,15 +216,9 @@ The `dataset_jax.data.array` is a `jax.Array`; `aplt.fits_imaging` and the
 plotters call `numpy.asarray()` internally, so saving / plotting works
 without manual conversion.
 
-Two notes:
-
-- Eager `simulator_jax.via_galaxies_from(galaxies, grid)` (no `@jax.jit`)
-  already runs on JAX and is sufficient for one-off simulations. The
-  `@jax.jit` wrap is only beneficial when you call the function many times.
-- The `@jax.jit` wrap is currently blocked by a pre-existing `Array2D.native`
-  jit-incompatibility in autoarray's slim/native reshape. Eager JAX works
-  today; the `@jax.jit` shown above will work once a separate refactor
-  task lands.
+Note: eager `simulator_jax.via_galaxies_from(galaxies, grid)` (no `@jax.jit`)
+already runs on JAX and is sufficient for one-off simulations. The
+`@jax.jit` wrap is only beneficial when you call the function many times.
 
 See `scripts/guides/api/data_structures.py` for the broader "JIT-it-
 yourself" pattern.

--- a/scripts/interferometer/simulator.py
+++ b/scripts/interferometer/simulator.py
@@ -222,9 +222,7 @@ Two notes:
   `nufftax` replacement is a research path (see
   `autolens_workspace_test/scripts/interferometer/nufft.py`).
 - Eager `simulator_jax.via_image_from(image)` already runs on JAX without
-  the `@jax.jit` wrap; the JIT wrap is currently blocked by a pre-existing
-  `Array2D.native` autoarray limitation. Eager use works today; the
-  `@jax.jit` wrap shown above will work once a separate refactor lands.
+  the `@jax.jit` wrap; the JIT only matters for repeated calls.
 
 See `scripts/guides/api/data_structures.py` for the broader "JIT-it-
 yourself" pattern.


### PR DESCRIPTION
## Summary

The `array_2d_via_indexes_from` jit-safety fix (PyAutoArray#339) makes `Array2D.native` jit-traceable. Removed the "currently blocked by a pre-existing Array2D.native autoarray limitation" notes from both simulator JAX variant blocks.

## Scripts Changed
- `scripts/imaging/simulator.py` — removed jit-blocked caveat from JAX variant notes
- `scripts/interferometer/simulator.py` — removed jit-blocked caveat from JAX variant notes

## Upstream PR
https://github.com/PyAutoLabs/PyAutoArray/pull/339

## Test Plan
- [ ] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)