### PR TITLE
interferometer: switch to TransformerNUFFT + apply_sparse_operator, reduce MGE to 5 Gaussians

### DIFF
--- a/scripts/interferometer/features/multi_gaussian_expansion/fit.py
+++ b/scripts/interferometer/features/multi_gaussian_expansion/fit.py
@@ -40,7 +40,7 @@ __Model__
 
 This script fits an `Interferometer` dataset of a galaxy with a model where:
 
- - The galaxy's bulge is a multi-Gaussian expansion of 30 linear `Gaussian` profiles, all sharing the
+ - The galaxy's bulge is a multi-Gaussian expansion of 5 linear `Gaussian` profiles, all sharing the
    same centre and `ell_comps`, with `sigma` values spanning 0.01" to the mask radius in log-spaced
    increments.
 
@@ -106,7 +106,7 @@ aplt.subplot_interferometer_dirty_images(dataset=dataset)
 """
 __Basis__
 
-We build a `Basis` of 30 linear `Gaussian` profiles, all sharing the same centre and `ell_comps`, with
+We build a `Basis` of 5 linear `Gaussian` profiles, all sharing the same centre and `ell_comps`, with
 `sigma` values spanning 0.01" to the mask radius in log-spaced increments.
 
 We use linear light profile Gaussians (`lp_linear.Gaussian`), which solve for each Gaussian's `intensity`
@@ -116,7 +116,7 @@ are needed to decompose the galaxy's morphology, and we cannot guess them by eye
 Linear light profiles are described in detail in the `linear_light_profiles.py` example; you should
 familiarize yourself with that example before using the multi-Gaussian expansion.
 """
-total_gaussians = 30
+total_gaussians = 5
 
 # The sigma values of the Gaussians will be fixed to values spanning 0.01 to the mask radius.
 log10_sigma_list = np.linspace(-2, np.log10(mask_radius), total_gaussians)

--- a/scripts/interferometer/features/multi_gaussian_expansion/likelihood_function.py
+++ b/scripts/interferometer/features/multi_gaussian_expansion/likelihood_function.py
@@ -110,13 +110,13 @@ aplt.subplot_interferometer_dirty_images(dataset=dataset)
 """
 __Galaxy MGE Basis__
 
-We build a `Basis` of 15 linear `Gaussian` profiles for the galaxy bulge, all sharing the same centre and
+We build a `Basis` of 5 linear `Gaussian` profiles for the galaxy bulge, all sharing the same centre and
 `ell_comps`, with `sigma` values spanning 0.01" to the mask radius in log-spaced increments.
 
 Each Gaussian is a linear light profile — its `intensity` is solved for analytically via the inversion
 below. Internally each linear profile carries `intensity=1.0`, which the inversion later rescales.
 """
-total_gaussians = 15
+total_gaussians = 5
 log10_sigma_list = np.linspace(-2, np.log10(mask_radius), total_gaussians)
 
 bulge_gaussian_list = []

--- a/scripts/interferometer/features/multi_gaussian_expansion/modeling.py
+++ b/scripts/interferometer/features/multi_gaussian_expansion/modeling.py
@@ -175,13 +175,13 @@ __Model__
 
 We compose a model where:
 
- - The galaxy's bulge is 30 linear `Gaussian` profiles [6 parameters total].
-   - The centres and elliptical components of the Gaussians are linked together in two groups of 15.
+ - The galaxy's bulge is 10 linear `Gaussian` profiles [6 parameters total].
+   - The centres and elliptical components of the Gaussians are linked together in two groups of 5.
    - The `sigma` size of the Gaussians increases in log10 increments from 0.01 to the mask radius.
 
 The number of free parameters and therefore the dimensionality of non-linear parameter space is N=6.
 
-The MGE comprises 2 groups of 15 Gaussians. Each group has its own elliptical components, so the galaxy's
+The MGE comprises 2 groups of 5 Gaussians. Each group has its own elliptical components, so the galaxy's
 light is decomposed into two distinct elliptical components which could be viewed as a bulge and a disk.
 
 __Model Cookbook__
@@ -190,7 +190,7 @@ A full description of model composition is provided by the model cookbook:
 
 https://pyautogalaxy.readthedocs.io/en/latest/general/model_cookbook.html
 """
-total_gaussians = 15
+total_gaussians = 5
 gaussian_per_basis = 2
 
 # The sigma values of the Gaussians will be fixed to values spanning 0.01 to the mask radius.

--- a/scripts/interferometer/features/pixelization/fit.py
+++ b/scripts/interferometer/features/pixelization/fit.py
@@ -167,7 +167,7 @@ dataset = ag.Interferometer.from_fits(
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
-    transformer_class=ag.TransformerDFT,
+    transformer_class=ag.TransformerNUFFT,
 )
 
 aplt.subplot_interferometer_dirty_images(dataset=dataset)
@@ -468,7 +468,7 @@ simulator = ag.SimulatorInterferometer(
     uv_wavelengths=dataset.uv_wavelengths,
     exposure_time=300.0,
     noise_sigma=1000.0,
-    transformer_class=ag.TransformerDFT,
+    transformer_class=ag.TransformerNUFFT,
 )
 
 dataset = simulator.via_image_from(image=interpolated_reconstruction)

--- a/scripts/interferometer/features/pixelization/galaxy_reconstruction.py
+++ b/scripts/interferometer/features/pixelization/galaxy_reconstruction.py
@@ -66,7 +66,7 @@ dataset = ag.Interferometer.from_fits(
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
-    transformer_class=ag.TransformerDFT,
+    transformer_class=ag.TransformerNUFFT,
 )
 
 dataset = dataset.apply_sparse_operator(use_jax=True, show_progress=True)

--- a/scripts/interferometer/features/pixelization/likelihood_function.py
+++ b/scripts/interferometer/features/pixelization/likelihood_function.py
@@ -122,7 +122,7 @@ dataset = ag.Interferometer.from_fits(
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
-    transformer_class=ag.TransformerDFT,
+    transformer_class=ag.TransformerNUFFT,
 )
 
 """

--- a/scripts/interferometer/features/pixelization/many_visibilities_preparation.py
+++ b/scripts/interferometer/features/pixelization/many_visibilities_preparation.py
@@ -84,7 +84,7 @@ dataset = ag.Interferometer.from_fits(
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
-    transformer_class=ag.TransformerDFT,
+    transformer_class=ag.TransformerNUFFT,
 )
 
 """

--- a/scripts/interferometer/features/pixelization/modeling.py
+++ b/scripts/interferometer/features/pixelization/modeling.py
@@ -196,7 +196,7 @@ dataset = ag.Interferometer.from_fits(
     noise_map_path=dataset_path / "noise_map.fits",
     uv_wavelengths_path=dataset_path / "uv_wavelengths.fits",
     real_space_mask=real_space_mask,
-    transformer_class=ag.TransformerDFT,
+    transformer_class=ag.TransformerNUFFT,
 )
 
 aplt.subplot_interferometer_dirty_images(dataset=dataset)


### PR DESCRIPTION
## Summary

- All pixelization examples flipped from `TransformerDFT` to `TransformerNUFFT` to use the production-relevant likelihood path. Without this, copying these examples to an ALMA-scale dataset would hit hours-long dirty-image setup.
- MGE examples reduced to `total_gaussians = 5` (matches `mge_model_from` default, fast on CPU).

## API Changes

None — pure workspace edits.

## Scripts Changed

- `features/multi_gaussian_expansion/{modeling,fit,likelihood_function}.py`
- `features/pixelization/{modeling,fit,galaxy_reconstruction,many_visibilities_preparation,likelihood_function}.py`

## Test plan

- [x] `check_sizes.sh` clean
- [x] Smoke tests pass with `PYAUTO_TEST_MODE=1` on representative scripts (modeling.py + fit.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)