### PR TITLE
docs(guides/results): thread test_mode segment through aggregator tutorial paths

### DIFF
--- a/scripts/guides/results/_quick_fit.py
+++ b/scripts/guides/results/_quick_fit.py
@@ -20,7 +20,9 @@ fast enough to fit inside the per-script CI timeout.
 import sys
 from pathlib import Path
 
-results_path = Path("output") / "results_folder"
+from autoconf.test_mode import with_test_mode_segment
+
+results_path = with_test_mode_segment(Path("output")) / "results_folder"
 if results_path.exists():
     sys.exit(0)
 

--- a/scripts/guides/results/aggregator/data_fitting.py
+++ b/scripts/guides/results/aggregator/data_fitting.py
@@ -46,6 +46,8 @@ especially if loading results from hard-disk is slow.
 import os
 from pathlib import Path
 
+from autoconf.test_mode import with_test_mode_segment
+
 import autofit as af
 import autogalaxy as ag
 import autogalaxy.plot as aplt
@@ -57,7 +59,7 @@ Set up the aggregator as shown in `start_here.py`.
 """
 from autofit.aggregator.aggregator import Aggregator
 
-results_path = Path("output") / "results_folder"
+results_path = with_test_mode_segment(Path("output")) / "results_folder"
 if not results_path.exists():
     import subprocess
     import sys

--- a/scripts/guides/results/aggregator/galaxies_fit.py
+++ b/scripts/guides/results/aggregator/galaxies_fit.py
@@ -48,6 +48,8 @@ If any code in this script is unclear, refer to the `results/start_here.ipynb` n
 # from autoconf import setup_notebook; setup_notebook()
 
 from pathlib import Path
+
+from autoconf.test_mode import with_test_mode_segment
 import autofit as af
 import autogalaxy as ag
 import autogalaxy.plot as aplt
@@ -60,7 +62,7 @@ The helper writes a capped Nautilus fit to ``output/results_folder/`` so this tu
 in this folder) have results to work with. When that folder already exists the helper exits immediately,
 so re-running this tutorial is cheap.
 """
-results_path = Path("output") / "results_folder"
+results_path = with_test_mode_segment(Path("output")) / "results_folder"
 if not results_path.exists():
     import subprocess
     import sys

--- a/scripts/guides/results/aggregator/models.py
+++ b/scripts/guides/results/aggregator/models.py
@@ -34,6 +34,8 @@ import os
 
 from pathlib import Path
 
+from autoconf.test_mode import with_test_mode_segment
+
 import autofit as af
 import autogalaxy as ag
 import autogalaxy.plot as aplt
@@ -46,7 +48,7 @@ Set up the aggregator as shown in `start_here.py`.
 """
 from autofit.aggregator.aggregator import Aggregator
 
-results_path = Path("output") / "results_folder"
+results_path = with_test_mode_segment(Path("output")) / "results_folder"
 if not results_path.exists():
     import subprocess
     import sys

--- a/scripts/guides/results/aggregator/queries.py
+++ b/scripts/guides/results/aggregator/queries.py
@@ -31,6 +31,8 @@ especially if loading results from hard-disk is slow.
 # from autoconf import setup_notebook; setup_notebook()
 
 from pathlib import Path
+
+from autoconf.test_mode import with_test_mode_segment
 import autofit as af
 import autogalaxy as ag
 
@@ -42,7 +44,7 @@ what the `Aggregator` does if you have not seen it!).
 """
 from autofit.aggregator.aggregator import Aggregator
 
-results_path = Path("output") / "results_folder"
+results_path = with_test_mode_segment(Path("output")) / "results_folder"
 if not results_path.exists():
     import subprocess
     import sys

--- a/scripts/guides/results/aggregator/samples.py
+++ b/scripts/guides/results/aggregator/samples.py
@@ -44,6 +44,8 @@ If any code in this script is unclear, refer to the `results/start_here.ipynb` n
 # from autoconf import setup_notebook; setup_notebook()
 
 from pathlib import Path
+
+from autoconf.test_mode import with_test_mode_segment
 import autofit as af
 import autogalaxy as ag
 import autogalaxy.plot as aplt
@@ -56,7 +58,7 @@ The helper writes a capped Nautilus fit to ``output/results_folder/`` so this tu
 in this folder) have results to work with. When that folder already exists the helper exits immediately,
 so re-running this tutorial is cheap.
 """
-results_path = Path("output") / "results_folder"
+results_path = with_test_mode_segment(Path("output")) / "results_folder"
 if not results_path.exists():
     import subprocess
     import sys

--- a/scripts/guides/results/aggregator/samples_via_aggregator.py
+++ b/scripts/guides/results/aggregator/samples_via_aggregator.py
@@ -47,6 +47,8 @@ the samples.
 # from autoconf import setup_notebook; setup_notebook()
 
 from pathlib import Path
+
+from autoconf.test_mode import with_test_mode_segment
 import autofit as af
 import autogalaxy.plot as aplt
 
@@ -82,7 +84,7 @@ but if not you can revert to the `samples.
 """
 from autofit.aggregator.aggregator import Aggregator
 
-results_path = Path("output") / "results_folder"
+results_path = with_test_mode_segment(Path("output")) / "results_folder"
 if not results_path.exists():
     import subprocess
     import sys


### PR DESCRIPTION
## Summary

Mirror of PyAutoLabs/autolens_workspace#215 for the autogalaxy mirror. Threads `autoconf.test_mode.with_test_mode_segment` through `_quick_fit.py` and 6 aggregator tutorial scripts (`data_fitting.py`, `galaxies_fit.py` — note singular vs autolens's plural, `models.py`, `queries.py`, `samples.py`, `samples_via_aggregator.py`).

Mechanical one-line replacement in each.

## Test plan

- [x] PyAutoConf #110 helper has unit tests.
- [ ] Local `autobuild run_all autogalaxy --timeout-secs 300` flips `guides/results/aggregator/{data_fitting, samples, galaxies_fit}.py` from FAIL to PASS once PyAutoConf #110 merges.

## Related

- PyAutoLabs/PyAutoConf#110 — adds the `with_test_mode_segment` helper.
- PyAutoLabs/autolens_workspace#215 — autolens twin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)