### PR TITLE
fix: reload saved result dataset with unchecked noise map

### DIFF
--- a/scripts/guides/results/start_here.py
+++ b/scripts/guides/results/start_here.py
@@ -236,6 +236,7 @@ if (image_path / "dataset.fits").exists():
         noise_map_hdu=2,
         psf_hdu=3,
         pixel_scales=0.1,
+        check_noise_map=False,
     )
 
 if (image_path / "galaxy_images.fits").exists():


### PR DESCRIPTION
## Summary
Allows the results guide to reload the saved combined imaging FITS generated by the script. The saved FITS stores masked noise-map pixels as zeroes, so the reload path disables noise-map validation for that already-produced result artifact.

## Scripts Changed
- `scripts/guides/results/start_here.py` — passes `check_noise_map=False` when reloading `image/dataset.fits` from the script output.

## Upstream PR
https://github.com/PyAutoLabs/PyAutoFit/pull/1317

## Test Plan
- [x] Targeted first-group release rerun passed `autogalaxy_workspace/scripts/guides/results/start_here.py`

Generated with Codex
